### PR TITLE
Implement insights-driven suggestions feature

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -97,6 +97,35 @@ body {
   margin: 0 auto;
 }
 
+.insights-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.subnav {
+  display: flex;
+  gap: 12px;
+  padding: 0 24px;
+  max-width: 1400px;
+  width: 100%;
+  margin: 18px auto 0;
+}
+
+.subnav a,
+.suggestions-card__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  text-decoration: none;
+}
+
 .page::before,
 .page::after {
   content: "";
@@ -239,7 +268,8 @@ h1 {
 .overview-grid,
 .platform-grid,
 .bottom-grid,
-.tracker-grid {
+.tracker-grid,
+.suggestion-grid {
   display: grid;
   gap: 24px;
 }
@@ -254,6 +284,10 @@ h1 {
 }
 
 .tracker-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.suggestion-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
@@ -420,6 +454,62 @@ li + li {
   border: 1px solid rgba(255, 79, 163, 0.22);
 }
 
+.suggestions-card__link {
+  margin-top: 18px;
+}
+
+.suggestion-card {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.suggestion-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 16px;
+}
+
+.suggestion-card__header h2 {
+  margin: 6px 0 0;
+  font-size: clamp(1.3rem, 2.4vw, 2rem);
+}
+
+.suggestion-card__confidence {
+  display: inline-flex;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(182, 255, 39, 0.12);
+  color: var(--lime-soft);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.suggestion-card__action,
+.suggestion-card__why {
+  margin: 0;
+  color: rgba(248, 255, 213, 0.86);
+  line-height: 1.6;
+}
+
+.suggestion-card__why {
+  color: rgba(248, 255, 213, 0.72);
+}
+
+.suggestion-card__footer {
+  padding: 16px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.suggestion-card__label {
+  margin: 0 0 10px;
+  color: var(--pink-soft);
+  font-weight: 700;
+}
+
 @media (min-width: 900px) {
   .panel {
     padding: 28px;
@@ -438,6 +528,7 @@ li + li {
   .platform-grid,
   .bottom-grid,
   .tracker-grid,
+  .suggestion-grid,
   .platform-card__analysis {
     grid-template-columns: 1fr;
   }

--- a/app/insights/layout.tsx
+++ b/app/insights/layout.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export default function InsightsLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="insights-shell">
+      <nav className="subnav" aria-label="Insights navigation">
+        <Link href="/insights">Overview</Link>
+        <Link href="/insights/suggestions">Suggestions</Link>
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -1,61 +1,5 @@
-const overviewStats = [
-  { label: "Combined Reach", value: "248k", change: "+18% this month" },
-  { label: "Follower Growth", value: "+3.4k", change: "+9% vs last month" },
-  { label: "Best Posting Window", value: "7-9 PM", change: "Weeknights win" },
-  { label: "Top Format", value: "Short video", change: "Reels + TikToks" }
-];
-
-const platformCards = [
-  {
-    name: "TikTok",
-    handle: "@maddie",
-    accent: "platform-card--pink",
-    stats: [
-      { label: "Views", value: "182k" },
-      { label: "Avg Watch Time", value: "11.8s" },
-      { label: "Shares", value: "3.2k" },
-      { label: "Saves", value: "1.1k" }
-    ],
-    wins: [
-      "Fast hook in the first 2 seconds",
-      "Playful captions are outperforming polished ones",
-      "Behind-the-scenes clips are driving shares"
-    ],
-    misses: [
-      "Long intros are losing retention",
-      "Posting before noon underperforms",
-      "Over-edited clips feel weaker"
-    ]
-  },
-  {
-    name: "Instagram",
-    handle: "@maddie",
-    accent: "platform-card--lime",
-    stats: [
-      { label: "Reach", value: "66k" },
-      { label: "Profile Visits", value: "8.7k" },
-      { label: "Saves", value: "2.6k" },
-      { label: "Story Replies", value: "480" }
-    ],
-    wins: [
-      "Reels with direct text overlays hold attention",
-      "Carousel posts create strong saves",
-      "Stories with polls increase replies"
-    ],
-    misses: [
-      "Single-image posts are lagging",
-      "Muted thumbnails are easy to skip",
-      "Weekend mornings are inconsistent"
-    ]
-  }
-];
-
-const suggestions = [
-  "Make 3 short videos this week that open with the payoff first, then the setup.",
-  "Turn one strong TikTok idea into an Instagram Reel and a carousel recap.",
-  "Use brighter cover text so the thumbnail sells the idea before people tap.",
-  "Test one story poll after every new post to pull people deeper into the funnel."
-];
+import Link from "next/link";
+import { overviewStats, platformCards, suggestions } from "@/lib/insights";
 
 export default function InsightsPage() {
   return (
@@ -150,13 +94,16 @@ export default function InsightsPage() {
         <article className="panel suggestions-card">
           <div className="suggestions-card__header">
             <p className="eyebrow">Suggestions</p>
-            <span className="suggestions-card__tag">Based on insights</span>
+            <span className="suggestions-card__tag">Generated from insights</span>
           </div>
           <ul>
             {suggestions.map((suggestion) => (
-              <li key={suggestion}>{suggestion}</li>
+              <li key={suggestion.title}>{suggestion.title}</li>
             ))}
           </ul>
+          <Link className="suggestions-card__link" href="/insights/suggestions">
+            Open full suggestions view
+          </Link>
         </article>
       </section>
     </main>

--- a/app/insights/suggestions/page.tsx
+++ b/app/insights/suggestions/page.tsx
@@ -1,0 +1,100 @@
+import { platformCards, suggestions } from "@/lib/insights";
+
+const focusMap: Record<string, string[]> = {
+  "Hook strategy": [
+    "Use payoff-first openings.",
+    "Cut setup lines that delay the good part.",
+    "Review which first 2 seconds create the best retention."
+  ],
+  "Content style": [
+    "Batch one more casual concept this week.",
+    "Keep edits tighter and less over-produced.",
+    "Reuse behind-the-scenes angles that already earned shares."
+  ],
+  Packaging: [
+    "Write cover text that promises a clear payoff.",
+    "Choose brighter, easier-to-read thumbnails.",
+    "Avoid muted covers that hide the idea."
+  ],
+  "Audience engagement": [
+    "Pair posts with a story poll or question.",
+    "Use replies to learn what angle to make next.",
+    "Treat stories as follow-up, not filler."
+  ],
+  Timing: [
+    "Put strong posts into the evening slot first.",
+    "Only test weak daytime windows intentionally.",
+    "Track whether weeknights keep beating early posts."
+  ]
+};
+
+export default function SuggestionsPage() {
+  return (
+    <main className="page">
+      <section className="hero panel">
+        <div>
+          <p className="eyebrow">Suggestions Engine</p>
+          <h1>Recommended next moves based on the signals already showing up in your content.</h1>
+          <p className="lede">
+            This page turns patterns from your insights into action ideas, so you
+            do not have to stare at numbers and guess what they mean.
+          </p>
+        </div>
+        <div className="hero__note">
+          <span className="hero__badge">Decision support</span>
+          <p>
+            These suggestions are generated from the current insights data model.
+            As the app gets real data later, the recommendations can get smarter too.
+          </p>
+        </div>
+      </section>
+
+      <section className="overview-grid">
+        <article className="stat-card panel">
+          <p className="stat-card__label">Suggestion Count</p>
+          <p className="stat-card__value">{suggestions.length}</p>
+          <p className="stat-card__change">Active recommendation areas</p>
+        </article>
+        <article className="stat-card panel">
+          <p className="stat-card__label">Based On</p>
+          <p className="stat-card__value">{platformCards.length} Platforms</p>
+          <p className="stat-card__change">TikTok + Instagram signals</p>
+        </article>
+        <article className="stat-card panel">
+          <p className="stat-card__label">Strongest Focus</p>
+          <p className="stat-card__value">Hooks</p>
+          <p className="stat-card__change">Retention is driving the advice</p>
+        </article>
+        <article className="stat-card panel">
+          <p className="stat-card__label">Format Bias</p>
+          <p className="stat-card__value">Short-form</p>
+          <p className="stat-card__change">Video-first strategy remains strongest</p>
+        </article>
+      </section>
+
+      <section className="suggestion-grid">
+        {suggestions.map((suggestion) => (
+          <article className="panel suggestion-card" key={suggestion.title}>
+            <div className="suggestion-card__header">
+              <div>
+                <p className="eyebrow">{suggestion.focus}</p>
+                <h2>{suggestion.title}</h2>
+              </div>
+              <span className="suggestion-card__confidence">{suggestion.confidence}</span>
+            </div>
+            <p className="suggestion-card__action">{suggestion.action}</p>
+            <p className="suggestion-card__why">{suggestion.why}</p>
+            <div className="suggestion-card__footer">
+              <p className="suggestion-card__label">Try this next</p>
+              <ul>
+                {(focusMap[suggestion.focus] ?? []).map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -1,0 +1,166 @@
+export type OverviewStat = {
+  label: string;
+  value: string;
+  change: string;
+};
+
+export type PlatformStat = {
+  label: string;
+  value: string;
+};
+
+export type PlatformInsight = {
+  name: "TikTok" | "Instagram";
+  handle: string;
+  accent: string;
+  stats: PlatformStat[];
+  wins: string[];
+  misses: string[];
+};
+
+export type InsightSuggestion = {
+  title: string;
+  action: string;
+  why: string;
+  focus: string;
+  confidence: "High confidence" | "Medium confidence";
+};
+
+export const overviewStats: OverviewStat[] = [
+  { label: "Combined Reach", value: "248k", change: "+18% this month" },
+  { label: "Follower Growth", value: "+3.4k", change: "+9% vs last month" },
+  { label: "Best Posting Window", value: "7-9 PM", change: "Weeknights win" },
+  { label: "Top Format", value: "Short video", change: "Reels + TikToks" }
+];
+
+export const platformCards: PlatformInsight[] = [
+  {
+    name: "TikTok",
+    handle: "@maddie",
+    accent: "platform-card--pink",
+    stats: [
+      { label: "Views", value: "182k" },
+      { label: "Avg Watch Time", value: "11.8s" },
+      { label: "Shares", value: "3.2k" },
+      { label: "Saves", value: "1.1k" }
+    ],
+    wins: [
+      "Fast hook in the first 2 seconds",
+      "Playful captions are outperforming polished ones",
+      "Behind-the-scenes clips are driving shares"
+    ],
+    misses: [
+      "Long intros are losing retention",
+      "Posting before noon underperforms",
+      "Over-edited clips feel weaker"
+    ]
+  },
+  {
+    name: "Instagram",
+    handle: "@maddie",
+    accent: "platform-card--lime",
+    stats: [
+      { label: "Reach", value: "66k" },
+      { label: "Profile Visits", value: "8.7k" },
+      { label: "Saves", value: "2.6k" },
+      { label: "Story Replies", value: "480" }
+    ],
+    wins: [
+      "Reels with direct text overlays hold attention",
+      "Carousel posts create strong saves",
+      "Stories with polls increase replies"
+    ],
+    misses: [
+      "Single-image posts are lagging",
+      "Muted thumbnails are easy to skip",
+      "Weekend mornings are inconsistent"
+    ]
+  }
+];
+
+export function buildSuggestions(platforms: PlatformInsight[]): InsightSuggestion[] {
+  const hasFastHookSignal = platforms.some((platform) =>
+    platform.wins.some((item) => item.toLowerCase().includes("hook"))
+  );
+  const hasCasualSignal = platforms.some((platform) =>
+    platform.wins.some((item) => item.toLowerCase().includes("playful"))
+  );
+  const hasStorySignal = platforms.some((platform) =>
+    platform.wins.some((item) => item.toLowerCase().includes("stories"))
+  );
+  const hasSlowIntroProblem = platforms.some((platform) =>
+    platform.misses.some((item) => item.toLowerCase().includes("long intros"))
+  );
+  const hasTimingProblem = platforms.some((platform) =>
+    platform.misses.some((item) => item.toLowerCase().includes("noon"))
+  );
+  const hasThumbnailProblem = platforms.some((platform) =>
+    platform.misses.some((item) => item.toLowerCase().includes("thumbnail"))
+  );
+
+  const suggestions: InsightSuggestion[] = [];
+
+  if (hasFastHookSignal || hasSlowIntroProblem) {
+    suggestions.push({
+      title: "Lead with the payoff faster",
+      action:
+        "Open your next batch of short-form videos with the most interesting moment first, then explain the setup after.",
+      why:
+        "Your current signals say fast hooks win attention while long intros lose retention, so the first seconds matter more than extra context.",
+      focus: "Hook strategy",
+      confidence: "High confidence"
+    });
+  }
+
+  if (hasCasualSignal) {
+    suggestions.push({
+      title: "Lean into content that feels more human than polished",
+      action:
+        "Make at least one casual, behind-the-scenes, or playful piece this week instead of over-editing every post.",
+      why:
+        "TikTok signals suggest playful captions and less polished energy are outperforming more produced content.",
+      focus: "Content style",
+      confidence: "Medium confidence"
+    });
+  }
+
+  if (hasThumbnailProblem) {
+    suggestions.push({
+      title: "Upgrade the promise on your cover frames",
+      action:
+        "Use clearer cover text and brighter thumbnails so the viewer understands the value of the post before tapping.",
+      why:
+        "Instagram signals suggest muted thumbnails are easy to skip, which means stronger visual packaging could improve entry into the content.",
+      focus: "Packaging",
+      confidence: "High confidence"
+    });
+  }
+
+  if (hasStorySignal) {
+    suggestions.push({
+      title: "Use stories to deepen the relationship after posting",
+      action:
+        "Pair new posts with a follow-up story poll or quick reply prompt to pull viewers into another touchpoint.",
+      why:
+        "Your Instagram story signals already show better replies when polls are used, so this is a repeatable follow-through move.",
+      focus: "Audience engagement",
+      confidence: "Medium confidence"
+    });
+  }
+
+  if (hasTimingProblem) {
+    suggestions.push({
+      title: "Prioritize evening publishing windows",
+      action:
+        "Queue your strongest posts for the 7-9 PM window before spending energy testing weak daytime slots again.",
+      why:
+        "The current dashboard says weeknights are stronger while earlier posting windows underperform.",
+      focus: "Timing",
+      confidence: "High confidence"
+    });
+  }
+
+  return suggestions;
+}
+
+export const suggestions = buildSuggestions(platformCards);


### PR DESCRIPTION
## Summary
- add a generated suggestions system backed by shared insights data
- create a dedicated suggestions route under Insights
- keep the overview page linked to the full suggestions view

## Verification
- confirmed localhost:3000 is serving the app
- confirmed /insights/suggestions responds
- ran PATH=/opt/homebrew/bin:/Users/madisynarmogida/.codex/tmp/arg0/codex-arg0mxFvd0:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm run lint

Closes #3