### PR TITLE
Refocus Maddie HQ on Instagram-only workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Maddie HQ is a growing web app for organizing the moving parts of Maddie's creat
 
 Right now, the app includes:
 - a home page that acts like the front door to the product
-- a Social Insights room for comparing TikTok and Instagram performance
+- an Instagram Insights room for reviewing Instagram performance
 - a Post Progress Tracker room for keeping up with day-to-day content tasks
 
 Over time, this project is meant to grow into a more complete operations app for Maddie's business, including better planning, insight review, and decision support.
@@ -163,9 +163,9 @@ The home page is the front door. It should help Maddie quickly understand what t
 This room is for understanding performance.
 
 It should eventually help answer questions like:
-- What is working on TikTok?
 - What is working on Instagram?
-- Which content patterns are worth repeating?
+- Which reels, carousels, or stories are worth repeating?
+- What patterns are helping saves, replies, and profile visits?
 - What should Maddie do more of next?
 
 ### Tracker

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -6,11 +6,11 @@ export default function InsightsPage() {
     <main className="page">
       <section className="hero panel">
         <div>
-          <p className="eyebrow">Social Insights</p>
-          <h1>One dashboard to track what your content is doing across TikTok and Instagram.</h1>
+          <p className="eyebrow">Instagram Insights</p>
+          <h1>One dashboard to track what your Instagram content is actually doing.</h1>
           <p className="lede">
-            This first version compares platform insights, spots what is working,
-            and gives you suggestions for what to try next.
+            This first version focuses on Instagram performance, spots what is
+            working, and gives you suggestions for what to try next.
           </p>
         </div>
         <div className="hero__note">
@@ -76,18 +76,18 @@ export default function InsightsPage() {
 
       <section className="bottom-grid">
         <article className="panel breakdown-card">
-          <p className="eyebrow">Cross-Platform Read</p>
-          <h2>Your strongest content is quick, direct, and feels a little more casual than polished.</h2>
+          <p className="eyebrow">Instagram Read</p>
+          <h2>Your strongest Instagram content is quick, direct, and visually easy to understand.</h2>
           <p>
-            Right now the pattern says your audience responds best when they know
-            the payoff early. Short-form video is carrying the most momentum, and
-            posts that feel human and immediate are beating content that feels too
-            staged.
+            Right now the pattern says your audience responds best when the value
+            of the content is obvious early. Reels are carrying the most momentum,
+            and posts that feel human and immediate are beating content that feels
+            too staged or too vague.
           </p>
           <p>
-            That means your system should focus on repeatable video ideas, stronger
-            hooks, and repurposing winners between platforms instead of reinventing
-            every post from scratch.
+            That means your system should focus on repeatable Instagram video ideas,
+            stronger hooks, clearer covers, and simpler follow-through instead of
+            reinventing every post from scratch.
           </p>
         </article>
 

--- a/app/insights/suggestions/page.tsx
+++ b/app/insights/suggestions/page.tsx
@@ -34,7 +34,7 @@ export default function SuggestionsPage() {
       <section className="hero panel">
         <div>
           <p className="eyebrow">Suggestions Engine</p>
-          <h1>Recommended next moves based on the signals already showing up in your content.</h1>
+          <h1>Recommended next moves based on the signals already showing up in your Instagram content.</h1>
           <p className="lede">
             This page turns patterns from your insights into action ideas, so you
             do not have to stare at numbers and guess what they mean.
@@ -57,8 +57,8 @@ export default function SuggestionsPage() {
         </article>
         <article className="stat-card panel">
           <p className="stat-card__label">Based On</p>
-          <p className="stat-card__value">{platformCards.length} Platforms</p>
-          <p className="stat-card__change">TikTok + Instagram signals</p>
+          <p className="stat-card__value">Instagram</p>
+          <p className="stat-card__change">{platformCards.length} insight profile in this MVP</p>
         </article>
         <article className="stat-card panel">
           <p className="stat-card__label">Strongest Focus</p>
@@ -67,8 +67,8 @@ export default function SuggestionsPage() {
         </article>
         <article className="stat-card panel">
           <p className="stat-card__label">Format Bias</p>
-          <p className="stat-card__value">Short-form</p>
-          <p className="stat-card__change">Video-first strategy remains strongest</p>
+          <p className="stat-card__value">Reels-first</p>
+          <p className="stat-card__change">Short-form Instagram strategy remains strongest</p>
         </article>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,16 +2,16 @@ import Link from "next/link";
 
 const homeCards = [
   {
-    title: "Social Insights",
+    title: "Instagram Insights",
     description:
-      "Compare TikTok and Instagram performance in one place, then spot what content is actually pulling its weight.",
+      "Review your Instagram performance in one place, then spot what content is actually pulling its weight.",
     href: "/insights",
     status: "Live now"
   },
   {
-    title: "Content Planner",
+    title: "Post Progress Tracker",
     description:
-      "Plan future posts, hooks, ideas, and themes so your content strategy does not live in scattered notes.",
+      "Track what is still an idea, what is being made, and what is ready to post so your Instagram workflow stays organized.",
     href: "/tracker",
     status: "Live now"
   },
@@ -30,21 +30,21 @@ export default function HomePage() {
       <section className="hero panel">
         <div>
           <p className="eyebrow">Maddie HQ</p>
-          <h1>A home base for the parts of your online business you want under control.</h1>
+          <h1>An Instagram creator home base for the parts of your workflow you want under control.</h1>
           <p className="lede">
             This site is now organized like a real app. Start from the homepage,
-            jump into the tools you want, and grow it over time instead of cramming
-            everything into one screen.
+            jump into the Instagram tools you want, and grow it over time instead
+            of cramming everything into one screen.
           </p>
         </div>
         <div className="hero__note">
-          <span className="hero__badge">Next Up</span>
+          <span className="hero__badge">Instagram-first</span>
           <p>
-            Right now your Social Insights dashboard and Tracker room are ready.
-            More tools can plug into this same structure as you decide what you need.
+            Right now your Instagram Insights dashboard and Tracker room are ready.
+            More creator tools can plug into this same structure as you decide what you need.
           </p>
           <Link className="hero__cta" href="/insights">
-            Open Social Insights
+            Open Instagram Insights
           </Link>
         </div>
       </section>

--- a/app/tracker/page.tsx
+++ b/app/tracker/page.tsx
@@ -1,7 +1,7 @@
 const todayStats = [
   { label: "Tasks Due Today", value: "7", detail: "2 high priority" },
-  { label: "Posts In Progress", value: "12", detail: "Across both platforms" },
-  { label: "Ready To Post", value: "3", detail: "1 TikTok, 2 Instagram" },
+  { label: "Posts In Progress", value: "12", detail: "Instagram workflow" },
+  { label: "Ready To Post", value: "3", detail: "2 Reels, 1 carousel" },
   { label: "Blocked Items", value: "2", detail: "Need assets or edits" }
 ];
 
@@ -12,7 +12,7 @@ const trackerColumns = [
     tasks: [
       {
         title: "Morning routine hook test",
-        platform: "TikTok",
+        platform: "Instagram Reel",
         due: "Today",
         note: "Try a faster first line and tighter caption."
       },
@@ -29,8 +29,8 @@ const trackerColumns = [
     description: "Content actively being made.",
     tasks: [
       {
-        title: "Behind-the-scenes clip batch",
-        platform: "TikTok",
+        title: "Behind-the-scenes Reel batch",
+        platform: "Instagram Reel",
         due: "Today",
         note: "Need final trims and cover text."
       },
@@ -48,15 +48,15 @@ const trackerColumns = [
     tasks: [
       {
         title: "Reel with direct text overlay",
-        platform: "Instagram",
+        platform: "Instagram Reel",
         due: "Tonight",
         note: "Caption approved. Needs final posting window."
       },
       {
-        title: "Quick payoff-first clip",
-        platform: "TikTok",
+        title: "Save-focused carousel recap",
+        platform: "Instagram Carousel",
         due: "Tomorrow",
-        note: "Strong watch-time candidate based on recent winners."
+        note: "Built from a Reel topic that already performed well."
       }
     ]
   },
@@ -66,15 +66,15 @@ const trackerColumns = [
     tasks: [
       {
         title: "Casual talking-head Reel",
-        platform: "Instagram",
+        platform: "Instagram Reel",
         due: "Posted",
         note: "Check saves and profile visits tomorrow."
       },
       {
-        title: "Playful caption trend post",
-        platform: "TikTok",
+        title: "Playful caption carousel",
+        platform: "Instagram Carousel",
         due: "Posted",
-        note: "Watch share rate during the first 24 hours."
+        note: "Watch saves and shares during the first 24 hours."
       }
     ]
   }
@@ -93,7 +93,7 @@ export default function TrackerPage() {
       <section className="hero panel">
         <div>
           <p className="eyebrow">Post Progress Tracker</p>
-          <h1>A day-to-day operations room for planning, making, and posting content.</h1>
+          <h1>A day-to-day operations room for planning, making, and posting Instagram content.</h1>
           <p className="lede">
             Use this space to track where each piece of content stands so you can
             see what is just an idea, what is being made, and what is ready to post.
@@ -102,8 +102,8 @@ export default function TrackerPage() {
         <div className="hero__note">
           <span className="hero__badge">Workflow</span>
           <p>
-            This room helps you manage the work itself, while Insights helps you
-            understand what happened after a post goes live.
+            This room helps you manage the Instagram work itself, while Insights
+            helps you understand what happened after a post goes live.
           </p>
         </div>
       </section>

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -10,7 +10,7 @@ export type PlatformStat = {
 };
 
 export type PlatformInsight = {
-  name: "TikTok" | "Instagram";
+  name: "Instagram";
   handle: string;
   accent: string;
   stats: PlatformStat[];
@@ -27,34 +27,13 @@ export type InsightSuggestion = {
 };
 
 export const overviewStats: OverviewStat[] = [
-  { label: "Combined Reach", value: "248k", change: "+18% this month" },
-  { label: "Follower Growth", value: "+3.4k", change: "+9% vs last month" },
+  { label: "Instagram Reach", value: "66k", change: "+18% this month" },
+  { label: "Profile Growth", value: "+1.1k", change: "+9% vs last month" },
   { label: "Best Posting Window", value: "7-9 PM", change: "Weeknights win" },
-  { label: "Top Format", value: "Short video", change: "Reels + TikToks" }
+  { label: "Top Format", value: "Reels", change: "Video-first content wins" }
 ];
 
 export const platformCards: PlatformInsight[] = [
-  {
-    name: "TikTok",
-    handle: "@maddie",
-    accent: "platform-card--pink",
-    stats: [
-      { label: "Views", value: "182k" },
-      { label: "Avg Watch Time", value: "11.8s" },
-      { label: "Shares", value: "3.2k" },
-      { label: "Saves", value: "1.1k" }
-    ],
-    wins: [
-      "Fast hook in the first 2 seconds",
-      "Playful captions are outperforming polished ones",
-      "Behind-the-scenes clips are driving shares"
-    ],
-    misses: [
-      "Long intros are losing retention",
-      "Posting before noon underperforms",
-      "Over-edited clips feel weaker"
-    ]
-  },
   {
     name: "Instagram",
     handle: "@maddie",
@@ -63,7 +42,8 @@ export const platformCards: PlatformInsight[] = [
       { label: "Reach", value: "66k" },
       { label: "Profile Visits", value: "8.7k" },
       { label: "Saves", value: "2.6k" },
-      { label: "Story Replies", value: "480" }
+      { label: "Story Replies", value: "480" },
+      { label: "Reel Plays", value: "124k" }
     ],
     wins: [
       "Reels with direct text overlays hold attention",
@@ -118,7 +98,7 @@ export function buildSuggestions(platforms: PlatformInsight[]): InsightSuggestio
       action:
         "Make at least one casual, behind-the-scenes, or playful piece this week instead of over-editing every post.",
       why:
-        "TikTok signals suggest playful captions and less polished energy are outperforming more produced content.",
+        "Instagram signals suggest playful captions and less polished energy are outperforming more produced content.",
       focus: "Content style",
       confidence: "Medium confidence"
     });


### PR DESCRIPTION
## Summary
- remove TikTok and mixed-platform framing from the product copy and sample data
- refocus the insights and suggestions experience around Instagram only
- align the homepage, tracker, and README with the new Instagram-first direction

## Verification
- confirmed localhost:3000 was serving updated routes
- checked /insights and /tracker content in the running app
- ran PATH=/opt/homebrew/bin:/Users/madisynarmogida/.codex/tmp/arg0/codex-arg0mxFvd0:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm run lint
- confirmed no remaining TikTok references in app/lib/README/AGENTS search

Closes #11