### PR TITLE
Add Instagram-to-OnlyFans conversion room

### DIFF
--- a/app/conversion/page.tsx
+++ b/app/conversion/page.tsx
@@ -1,0 +1,129 @@
+import {
+  convertingReels,
+  explanationPoints,
+  funnelStages,
+  managerNotes,
+  revenueSignals
+} from "@/lib/conversion";
+
+export default function ConversionPage() {
+  return (
+    <main className="page">
+      <section className="hero panel">
+        <div>
+          <p className="eyebrow">Conversion Room</p>
+          <h1>See whether your Instagram content is actually translating into OnlyFans results.</h1>
+          <p className="lede">
+            This room is about the funnel from attention to money. It helps you
+            see where people are dropping off, where they are converting, and what
+            kinds of reels appear to bring in stronger business outcomes.
+          </p>
+        </div>
+        <div className="hero__note">
+          <span className="hero__badge">Business layer</span>
+          <p>
+            Insights tells you how content performs. Conversion tells you whether
+            that attention is actually moving toward OF traffic and paid action.
+          </p>
+        </div>
+      </section>
+
+      <section className="overview-grid">
+        {revenueSignals.map((signal) => (
+          <article className="stat-card panel" key={signal.label}>
+            <p className="stat-card__label">{signal.label}</p>
+            <p className="stat-card__value">{signal.value}</p>
+            <p className="stat-card__change">{signal.note}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="panel funnel-card">
+        <div className="funnel-card__header">
+          <div>
+            <p className="eyebrow">Funnel Snapshot</p>
+            <h2>From Reel attention to paid conversion.</h2>
+          </div>
+          <span className="suggestions-card__tag">Instagram to OF</span>
+        </div>
+        <div className="funnel-grid">
+          {funnelStages.map((stage, index) => (
+            <article className="funnel-stage" key={stage.label}>
+              <p className="funnel-stage__step">Step {index + 1}</p>
+              <p className="funnel-stage__label">{stage.label}</p>
+              <p className="funnel-stage__value">{stage.value}</p>
+              <p className="funnel-stage__detail">{stage.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="conversion-grid">
+        <article className="panel">
+          <div className="suggestions-card__header">
+            <p className="eyebrow">Top Converting Reels</p>
+            <span className="suggestions-card__tag">Revenue signals</span>
+          </div>
+          <div className="reel-list">
+            {convertingReels.map((reel) => (
+              <article className="reel-card" key={reel.title}>
+                <h3>{reel.title}</h3>
+                <p className="reel-card__hook">{reel.hook}</p>
+                <div className="reel-card__metrics">
+                  <span>{reel.reach}</span>
+                  <span>{reel.profileActions}</span>
+                  <span>{reel.ofSignal}</span>
+                </div>
+                <p className="reel-card__takeaway">{reel.takeaway}</p>
+              </article>
+            ))}
+          </div>
+        </article>
+
+        <article className="panel">
+          <div className="suggestions-card__header">
+            <p className="eyebrow">What This Means</p>
+            <span className="suggestions-card__tag">Explained simply</span>
+          </div>
+          <div className="explanation-list">
+            {explanationPoints.map((point) => (
+              <article className="explanation-card" key={point.title}>
+                <h3>{point.title}</h3>
+                <p>{point.body}</p>
+              </article>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="bottom-grid">
+        <article className="panel breakdown-card">
+          <p className="eyebrow">Current Read</p>
+          <h2>Your biggest opportunity is not more reach. It is improving the handoff from Instagram interest into stronger OF intent.</h2>
+          <p>
+            In this MVP sample, the top of the funnel is healthy enough to work
+            with. The more valuable question is what makes someone move from
+            &quot;that reel was interesting&quot; to &quot;I want more of this creator right now.&quot;
+          </p>
+          <p>
+            The posts that convert best appear to create clarity fast, feel personal,
+            and make the next step feel natural rather than forced. That is the pattern
+            to keep pressure-testing.
+          </p>
+        </article>
+
+        <article className="panel suggestions-card">
+          <div className="suggestions-card__header">
+            <p className="eyebrow">Manager Notes</p>
+            <span className="suggestions-card__tag">Useful to track</span>
+          </div>
+          <ul>
+            {managerNotes.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -269,7 +269,9 @@ h1 {
 .platform-grid,
 .bottom-grid,
 .tracker-grid,
-.suggestion-grid {
+.suggestion-grid,
+.conversion-grid,
+.funnel-grid {
   display: grid;
   gap: 24px;
 }
@@ -289,6 +291,14 @@ h1 {
 
 .suggestion-grid {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.conversion-grid {
+  grid-template-columns: 1.15fr 0.85fr;
+}
+
+.funnel-grid {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
 }
 
 .stat-card__label,
@@ -510,6 +520,97 @@ li + li {
   font-weight: 700;
 }
 
+.funnel-card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.funnel-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 16px;
+}
+
+.funnel-card__header h2 {
+  margin: 6px 0 0;
+  font-size: clamp(1.4rem, 2.8vw, 2.2rem);
+}
+
+.funnel-stage,
+.reel-card,
+.explanation-card {
+  padding: 18px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.funnel-stage__step,
+.funnel-stage__label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.funnel-stage__step {
+  color: var(--pink-soft);
+  font-size: 0.74rem;
+}
+
+.funnel-stage__label {
+  margin-top: 10px;
+  color: rgba(248, 255, 213, 0.72);
+  font-size: 0.82rem;
+}
+
+.funnel-stage__value {
+  margin: 12px 0 8px;
+  color: var(--lime-soft);
+  font-size: clamp(1.7rem, 3vw, 2.3rem);
+  font-weight: 700;
+}
+
+.funnel-stage__detail,
+.reel-card__hook,
+.reel-card__takeaway,
+.explanation-card p {
+  margin: 0;
+  color: rgba(248, 255, 213, 0.78);
+  line-height: 1.6;
+}
+
+.reel-list,
+.explanation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.reel-card h3,
+.explanation-card h3 {
+  margin: 0 0 10px;
+  font-size: 1.05rem;
+}
+
+.reel-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 14px 0;
+}
+
+.reel-card__metrics span {
+  display: inline-flex;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(182, 255, 39, 0.1);
+  color: var(--lime-soft);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
 @media (min-width: 900px) {
   .panel {
     padding: 28px;
@@ -529,6 +630,8 @@ li + li {
   .bottom-grid,
   .tracker-grid,
   .suggestion-grid,
+  .conversion-grid,
+  .funnel-grid,
   .platform-card__analysis {
     grid-template-columns: 1fr;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({
               <Link href="/">Home</Link>
               <Link href="/insights">Insights</Link>
               <Link href="/tracker">Tracker</Link>
+              <Link href="/conversion">Conversion</Link>
               <button className="topbar__menu" type="button">
                 More Tools Soon
               </button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,11 +16,11 @@ const homeCards = [
     status: "Live now"
   },
   {
-    title: "Suggestions Engine",
+    title: "Conversion Room",
     description:
-      "Turn insights into recommendations for what to post more of, what to cut, and what to test next.",
-    href: "#",
-    status: "Coming soon"
+      "See whether your Instagram content is actually translating into profile actions, OF traffic, and paid outcomes.",
+    href: "/conversion",
+    status: "Live now"
   }
 ];
 
@@ -40,8 +40,8 @@ export default function HomePage() {
         <div className="hero__note">
           <span className="hero__badge">Instagram-first</span>
           <p>
-            Right now your Instagram Insights dashboard and Tracker room are ready.
-            More creator tools can plug into this same structure as you decide what you need.
+            Right now your Instagram Insights dashboard, Tracker room, and Conversion
+            room are ready. More creator tools can plug into this same structure as you decide what you need.
           </p>
           <Link className="hero__cta" href="/insights">
             Open Instagram Insights
@@ -57,13 +57,9 @@ export default function HomePage() {
               <h2>{card.title}</h2>
             </div>
             <p>{card.description}</p>
-            {card.href === "#" ? (
-              <span className="home-card__link home-card__link--muted">Available later</span>
-            ) : (
-              <Link className="home-card__link" href={card.href}>
-                Open tool
-              </Link>
-            )}
+            <Link className="home-card__link" href={card.href}>
+              Open tool
+            </Link>
           </article>
         ))}
       </section>

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -1,0 +1,102 @@
+export type FunnelStage = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+export type ConvertingReel = {
+  title: string;
+  hook: string;
+  reach: string;
+  profileActions: string;
+  ofSignal: string;
+  takeaway: string;
+};
+
+export type RevenueSignal = {
+  label: string;
+  value: string;
+  note: string;
+};
+
+export const funnelStages: FunnelStage[] = [
+  { label: "Instagram Reach", value: "66k", detail: "People who saw the reel content." },
+  { label: "Profile Visits", value: "8.7k", detail: "People curious enough to check your page." },
+  { label: "Link / DM Actions", value: "1.4k", detail: "People taking a stronger intent step." },
+  { label: "OnlyFans Visits", value: "620", detail: "Traffic that actually reached the OF side." },
+  { label: "Paid Conversions", value: "94", detail: "The outcomes that matter most for revenue." }
+];
+
+export const revenueSignals: RevenueSignal[] = [
+  {
+    label: "Estimated Conversion Rate",
+    value: "15.2%",
+    note: "From OF visits to paid conversions in this MVP sample."
+  },
+  {
+    label: "Strongest Traffic Source",
+    value: "Reels",
+    note: "Short-form Instagram is driving the best top-of-funnel volume."
+  },
+  {
+    label: "Best Mid-Funnel Step",
+    value: "Profile Visits",
+    note: "Your page is doing a decent job turning attention into curiosity."
+  },
+  {
+    label: "Biggest Drop-Off",
+    value: "Link to OF",
+    note: "This is where the business opportunity likely lives right now."
+  }
+];
+
+export const convertingReels: ConvertingReel[] = [
+  {
+    title: "Fast payoff morning reel",
+    hook: "Started with the strongest visual in the first second.",
+    reach: "18k reach",
+    profileActions: "1.8k profile visits",
+    ofSignal: "142 OF visits / 21 paid conversions",
+    takeaway: "Fast clarity and direct payoff created both attention and buyer intent."
+  },
+  {
+    title: "Soft-spoken behind-the-scenes reel",
+    hook: "Casual tone, lower polish, more personal energy.",
+    reach: "11k reach",
+    profileActions: "1.1k profile visits",
+    ofSignal: "97 OF visits / 18 paid conversions",
+    takeaway: "This did not have the biggest reach, but it attracted stronger-fit traffic."
+  },
+  {
+    title: "Text-overlay teaser reel",
+    hook: "Cover text made the promise immediately obvious.",
+    reach: "23k reach",
+    profileActions: "2.3k profile visits",
+    ofSignal: "161 OF visits / 24 paid conversions",
+    takeaway: "Clear packaging made it easier for the right viewer to keep moving down the funnel."
+  }
+];
+
+export const explanationPoints = [
+  {
+    title: "What this room is for",
+    body:
+      "This is where content performance stops being vanity and starts being business. The point is to see whether Instagram attention is creating actual OnlyFans outcomes."
+  },
+  {
+    title: "What good looks like",
+    body:
+      "A healthy funnel does not just get reach. It gets the right people to visit the profile, take action, and continue into paid behavior."
+  },
+  {
+    title: "What to watch closely",
+    body:
+      "The biggest drop-off usually matters more than the biggest top-line number. If your reach is strong but your OF visits are weak, the handoff needs work."
+  }
+];
+
+export const managerNotes = [
+  "Track each Reel separately so you can compare reach versus buyer-intent behavior, not just views.",
+  "Log any manager tactic changes near the same time as a post so you can connect strategy to outcome later.",
+  "When something converts unusually well, save the exact hook, thumbnail, caption tone, and posting window."
+];


### PR DESCRIPTION
## Summary
- add a new top-level Conversion room for Instagram-to-OnlyFans funnel tracking
- add MVP sample data for funnel stages, revenue signals, and top converting reels
- connect the new room into the homepage and top navigation

## Verification
- checked /conversion in the running app on localhost:3000
- checked homepage navigation and Conversion card
- ran PATH=/opt/homebrew/bin:/Users/madisynarmogida/.codex/tmp/arg0/codex-arg0mxFvd0:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm run lint

Closes #13