### PR TITLE
Persist manual conversion inputs locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ This log exists so the agent does not keep asking Maddie the same crash-course q
 - Conversion funnel: taught on 2026-03-17.
 - KPI: taught on 2026-03-17.
 - Derived metric: taught on 2026-03-17.
+- Database: taught on 2026-03-17.
+- Authentication: taught on 2026-03-17.
 
 ## Execution Rules
 

--- a/app/conversion/page.tsx
+++ b/app/conversion/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   buildConversionSummary,
   defaultConversionInputs,
@@ -9,8 +9,11 @@ import {
   type ConversionInputs
 } from "@/lib/conversion";
 
+const STORAGE_KEY = "maddiehq:conversion-inputs";
+
 export default function ConversionPage() {
   const [inputs, setInputs] = useState<ConversionInputs>(defaultConversionInputs);
+  const [saveState, setSaveState] = useState("Using starter values");
   const summary = useMemo(() => buildConversionSummary(inputs), [inputs]);
 
   const inputFields: Array<{
@@ -27,6 +30,34 @@ export default function ConversionPage() {
     { key: "tipsCount", label: "Tips Count", help: "How often people tipped during the period." },
     { key: "topSpenderAmount", label: "Top Spender Amount", help: "Highest spender amount for the period." }
   ];
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!saved) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as Partial<ConversionInputs>;
+      setInputs((current) => ({
+        ...current,
+        ...Object.fromEntries(
+          Object.entries(parsed).filter((entry): entry is [keyof ConversionInputs, number] =>
+            typeof entry[1] === "number"
+          )
+        )
+      }));
+      setSaveState("Loaded your saved values");
+    } catch {
+      setSaveState("Could not read saved values");
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(inputs));
+    setSaveState("Saved on this device");
+  }, [inputs]);
 
   return (
     <main className="page">
@@ -46,6 +77,7 @@ export default function ConversionPage() {
             Insights tells you how content performs. Conversion tells you whether
             that attention is actually moving toward OF traffic and paid action.
           </p>
+          <p className="hero__save-state">{saveState}</p>
         </div>
       </section>
 
@@ -84,6 +116,22 @@ export default function ConversionPage() {
           <div className="suggestions-card__header">
             <p className="eyebrow">Manual Input</p>
             <span className="suggestions-card__tag">Use your real numbers</span>
+          </div>
+          <div className="input-toolbar">
+            <p className="input-toolbar__text">
+              These values now save in this browser, so you can refresh without losing them.
+            </p>
+            <button
+              className="input-toolbar__button"
+              type="button"
+              onClick={() => {
+                setInputs(defaultConversionInputs);
+                window.localStorage.removeItem(STORAGE_KEY);
+                setSaveState("Reset to starter values");
+              }}
+            >
+              Reset values
+            </button>
           </div>
           <div className="input-grid">
             {inputFields.map((field) => (

--- a/app/globals.css
+++ b/app/globals.css
@@ -203,6 +203,13 @@ h1 {
   background: linear-gradient(180deg, rgba(255, 79, 163, 0.15), rgba(182, 255, 39, 0.12));
 }
 
+.hero__save-state {
+  margin: 0;
+  color: #234600;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
 .hero__badge,
 .platform-card__pill,
 .suggestions-card__tag {
@@ -595,6 +602,30 @@ li + li {
   margin-bottom: 18px;
 }
 
+.input-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 18px;
+}
+
+.input-toolbar__text {
+  margin: 0;
+  color: rgba(248, 255, 213, 0.76);
+  line-height: 1.5;
+}
+
+.input-toolbar__button {
+  padding: 10px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  background: rgba(255, 79, 163, 0.12);
+  color: var(--pink-soft);
+  font: inherit;
+  font-weight: 700;
+}
+
 .input-card {
   display: flex;
   flex-direction: column;
@@ -914,6 +945,11 @@ li + li {
 
   .metric-grid {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .input-toolbar {
+    flex-direction: column;
+    align-items: start;
   }
 
   .input-grid {


### PR DESCRIPTION
## Summary
- persist the manual conversion inputs in browser storage so they survive refreshes
- add save-state messaging and a reset button to the Conversion room
- log the database/auth crash-course topics in AGENTS.md

## Verification
- checked /conversion in the running app on localhost:3000
- confirmed save/reset messaging rendered in the UI
- ran PATH=/opt/homebrew/bin:/Users/madisynarmogida/.codex/tmp/arg0/codex-arg0mxFvd0:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm run lint

Closes #19