### PR TITLE
Add creator account foundation

### DIFF
--- a/app/conversion/page.tsx
+++ b/app/conversion/page.tsx
@@ -1,20 +1,22 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useCreator } from "@/components/creator-provider";
 import {
   buildConversionSummary,
+  buildConversionStorageKey,
   defaultConversionInputs,
   formatWholeNumber,
   managerNotes,
   type ConversionInputs
 } from "@/lib/conversion";
 
-const STORAGE_KEY = "maddiehq:conversion-inputs";
-
 export default function ConversionPage() {
+  const { activeProfile } = useCreator();
   const [inputs, setInputs] = useState<ConversionInputs>(defaultConversionInputs);
   const [saveState, setSaveState] = useState("Using starter values");
   const summary = useMemo(() => buildConversionSummary(inputs), [inputs]);
+  const storageKey = useMemo(() => buildConversionStorageKey(activeProfile.id), [activeProfile.id]);
 
   const inputFields: Array<{
     key: keyof ConversionInputs;
@@ -32,9 +34,11 @@ export default function ConversionPage() {
   ];
 
   useEffect(() => {
-    const saved = window.localStorage.getItem(STORAGE_KEY);
+    const saved = window.localStorage.getItem(storageKey);
 
     if (!saved) {
+      setInputs(defaultConversionInputs);
+      setSaveState(`Using starter values for ${activeProfile.name}`);
       return;
     }
 
@@ -48,16 +52,16 @@ export default function ConversionPage() {
           )
         )
       }));
-      setSaveState("Loaded your saved values");
+      setSaveState(`Loaded saved values for ${activeProfile.name}`);
     } catch {
       setSaveState("Could not read saved values");
     }
-  }, []);
+  }, [activeProfile.name, storageKey]);
 
   useEffect(() => {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(inputs));
-    setSaveState("Saved on this device");
-  }, [inputs]);
+    window.localStorage.setItem(storageKey, JSON.stringify(inputs));
+    setSaveState(`Saved for ${activeProfile.name} on this device`);
+  }, [activeProfile.name, inputs, storageKey]);
 
   return (
     <main className="page">
@@ -126,8 +130,8 @@ export default function ConversionPage() {
               type="button"
               onClick={() => {
                 setInputs(defaultConversionInputs);
-                window.localStorage.removeItem(STORAGE_KEY);
-                setSaveState("Reset to starter values");
+                window.localStorage.removeItem(storageKey);
+                setSaveState(`Reset ${activeProfile.name} to starter values`);
               }}
             >
               Reset values

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState } from "react";
+import { useCreator } from "@/components/creator-provider";
+
+export default function CreatorPage() {
+  const {
+    profiles,
+    activeProfile,
+    activeProfileId,
+    addProfile,
+    setActiveProfileId,
+    updateActiveProfile
+  } = useCreator();
+  const [newProfileName, setNewProfileName] = useState("");
+
+  return (
+    <main className="page">
+      <section className="hero panel">
+        <div>
+          <p className="eyebrow">Creator Foundation</p>
+          <h1>Start telling the app which creator it is working for and how her Instagram account should connect.</h1>
+          <p className="lede">
+            This is the first real account layer. It lets the app know which creator
+            is active, keeps saved data scoped to that creator, and gives us a place
+            to prepare the Instagram connection setup.
+          </p>
+        </div>
+        <div className="hero__note">
+          <span className="hero__badge">Foundation</span>
+          <p>
+            This is not full live login yet. It is the groundwork that makes later
+            authentication and Instagram sync much cleaner to build.
+          </p>
+        </div>
+      </section>
+
+      <section className="creator-grid">
+        <article className="panel">
+          <div className="suggestions-card__header">
+            <p className="eyebrow">Creator Profile</p>
+            <span className="suggestions-card__tag">Who this data belongs to</span>
+          </div>
+          <div className="creator-form">
+            <label className="input-card">
+              <span className="input-card__label">Active Creator</span>
+              <select
+                className="input-card__field"
+                value={activeProfileId}
+                onChange={(event) => setActiveProfileId(event.target.value)}
+              >
+                {profiles.map((profile) => (
+                  <option key={profile.id} value={profile.id}>
+                    {profile.name}
+                  </option>
+                ))}
+              </select>
+              <span className="input-card__help">
+                Switching the active creator changes which saved app data is being used.
+              </span>
+            </label>
+
+            <div className="creator-add">
+              <input
+                className="input-card__field"
+                placeholder="Add another creator name"
+                value={newProfileName}
+                onChange={(event) => setNewProfileName(event.target.value)}
+              />
+              <button
+                className="input-toolbar__button"
+                type="button"
+                onClick={() => {
+                  addProfile(newProfileName);
+                  setNewProfileName("");
+                }}
+              >
+                Add creator
+              </button>
+            </div>
+
+            <label className="input-card">
+              <span className="input-card__label">Creator Name</span>
+              <input
+                className="input-card__field"
+                value={activeProfile.name}
+                onChange={(event) => updateActiveProfile({ name: event.target.value })}
+              />
+            </label>
+
+            <label className="input-card">
+              <span className="input-card__label">Instagram Handle</span>
+              <input
+                className="input-card__field"
+                value={activeProfile.instagramHandle}
+                onChange={(event) =>
+                  updateActiveProfile({ instagramHandle: event.target.value })
+                }
+              />
+            </label>
+          </div>
+        </article>
+
+        <article className="panel">
+          <div className="suggestions-card__header">
+            <p className="eyebrow">Instagram Connection Setup</p>
+            <span className="suggestions-card__tag">Prep for live sync</span>
+          </div>
+          <div className="creator-form">
+            <label className="input-card">
+              <span className="input-card__label">Account Type</span>
+              <select
+                className="input-card__field"
+                value={activeProfile.accountType}
+                onChange={(event) =>
+                  updateActiveProfile({
+                    accountType: event.target.value as "Creator" | "Business"
+                  })
+                }
+              >
+                <option value="Creator">Creator</option>
+                <option value="Business">Business</option>
+              </select>
+            </label>
+
+            <label className="checkbox-row">
+              <input
+                type="checkbox"
+                checked={activeProfile.facebookPageLinked}
+                onChange={(event) =>
+                  updateActiveProfile({ facebookPageLinked: event.target.checked })
+                }
+              />
+              <span>Instagram is linked to the required Facebook Page</span>
+            </label>
+
+            <label className="checkbox-row">
+              <input
+                type="checkbox"
+                checked={activeProfile.insightsPermissionReady}
+                onChange={(event) =>
+                  updateActiveProfile({ insightsPermissionReady: event.target.checked })
+                }
+              />
+              <span>Meta app / insights permission setup is ready for connection work</span>
+            </label>
+
+            <label className="input-card">
+              <span className="input-card__label">Connection Status</span>
+              <select
+                className="input-card__field"
+                value={activeProfile.status}
+                onChange={(event) =>
+                  updateActiveProfile({
+                    status: event.target.value as
+                      | "Setup needed"
+                      | "Ready to connect"
+                      | "Connected later"
+                  })
+                }
+              >
+                <option value="Setup needed">Setup needed</option>
+                <option value="Ready to connect">Ready to connect</option>
+                <option value="Connected later">Connected later</option>
+              </select>
+            </label>
+          </div>
+        </article>
+      </section>
+
+      <section className="bottom-grid">
+        <article className="panel breakdown-card">
+          <p className="eyebrow">What This Unlocks</p>
+          <h2>This is the bridge from a one-browser prototype into a real creator app.</h2>
+          <p>
+            Once the app knows which creator is active, saved numbers can belong to
+            that creator instead of some generic browser session. That is what makes
+            future cloud saving, creator accounts, and account-specific insights possible.
+          </p>
+          <p>
+            A real live Instagram login still needs Meta app credentials and OAuth.
+            This page gives that future connection a proper place to live in the product.
+          </p>
+        </article>
+
+        <article className="panel suggestions-card">
+          <div className="suggestions-card__header">
+            <p className="eyebrow">Known Limitation</p>
+            <span className="suggestions-card__tag">Before live Instagram sync</span>
+          </div>
+          <ul>
+            <li>Real Instagram connection still needs a Meta app and OAuth flow.</li>
+            <li>The creator account should be a professional account for insights access.</li>
+            <li>Meta permissions and app review work still have to be done for live data.</li>
+          </ul>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -72,6 +72,28 @@ body {
   flex-wrap: wrap;
 }
 
+.topbar__profile {
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+  gap: 2px;
+  padding: 10px 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.topbar__profile-name {
+  color: var(--lime-soft);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.topbar__profile-handle {
+  color: rgba(248, 255, 213, 0.72);
+  font-size: 0.82rem;
+}
+
 .topbar__nav a,
 .topbar__menu {
   padding: 10px 14px;
@@ -302,6 +324,12 @@ h1 {
 
 .conversion-grid {
   grid-template-columns: 1.15fr 0.85fr;
+}
+
+.creator-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
 }
 
 .funnel-grid {
@@ -665,6 +693,29 @@ li + li {
   line-height: 1.45;
 }
 
+.creator-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.creator-add {
+  display: flex;
+  gap: 12px;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: start;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  color: rgba(248, 255, 213, 0.82);
+  line-height: 1.5;
+}
+
 .reel-card h3,
 .explanation-card h3 {
   margin: 0 0 10px;
@@ -930,6 +981,10 @@ li + li {
     align-items: start;
   }
 
+  .topbar__profile {
+    align-items: start;
+  }
+
   .hero,
   .home-grid,
   .overview-grid,
@@ -938,6 +993,7 @@ li + li {
   .tracker-grid,
   .suggestion-grid,
   .conversion-grid,
+  .creator-grid,
   .funnel-grid,
   .platform-card__analysis {
     grid-template-columns: 1fr;
@@ -950,6 +1006,10 @@ li + li {
   .input-toolbar {
     flex-direction: column;
     align-items: start;
+  }
+
+  .creator-add {
+    flex-direction: column;
   }
 
   .input-grid {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import Link from "next/link";
+import { Providers } from "@/app/providers";
+import { Topbar } from "@/components/topbar";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,23 +17,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <div className="app-shell">
-          <header className="topbar">
-            <Link className="topbar__brand" href="/">
-              Maddie HQ
-            </Link>
-            <nav className="topbar__nav" aria-label="Main navigation">
-              <Link href="/">Home</Link>
-              <Link href="/insights">Insights</Link>
-              <Link href="/tracker">Tracker</Link>
-              <Link href="/conversion">Conversion</Link>
-              <button className="topbar__menu" type="button">
-                More Tools Soon
-              </button>
-            </nav>
-          </header>
-          {children}
-        </div>
+        <Providers>
+          <div className="app-shell">
+            <Topbar />
+            {children}
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,13 @@ const homeCards = [
       "See whether your Instagram content is actually translating into profile actions, OF traffic, and paid outcomes.",
     href: "/conversion",
     status: "Live now"
+  },
+  {
+    title: "Creator Setup",
+    description:
+      "Choose the active creator profile and prepare the Instagram connection foundation for future live insights sync.",
+    href: "/creator",
+    status: "Foundation"
   }
 ];
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { CreatorProvider } from "@/components/creator-provider";
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <CreatorProvider>{children}</CreatorProvider>;
+}

--- a/components/creator-provider.tsx
+++ b/components/creator-provider.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from "react";
+import { defaultCreatorProfile, type CreatorProfile } from "@/lib/creator";
+
+type CreatorContextValue = {
+  profiles: CreatorProfile[];
+  activeProfile: CreatorProfile;
+  activeProfileId: string;
+  setActiveProfileId: (id: string) => void;
+  updateActiveProfile: (updates: Partial<CreatorProfile>) => void;
+  addProfile: (name: string) => void;
+};
+
+const STORAGE_KEY = "maddiehq:creator-state";
+const CreatorContext = createContext<CreatorContextValue | null>(null);
+
+export function CreatorProvider({ children }: { children: ReactNode }) {
+  const [profiles, setProfiles] = useState<CreatorProfile[]>([defaultCreatorProfile]);
+  const [activeProfileId, setActiveProfileId] = useState(defaultCreatorProfile.id);
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!saved) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as {
+        profiles?: CreatorProfile[];
+        activeProfileId?: string;
+      };
+
+      if (parsed.profiles?.length) {
+        setProfiles(parsed.profiles);
+      }
+
+      if (parsed.activeProfileId) {
+        setActiveProfileId(parsed.activeProfileId);
+      }
+    } catch {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ profiles, activeProfileId }));
+  }, [profiles, activeProfileId]);
+
+  const activeProfile =
+    profiles.find((profile) => profile.id === activeProfileId) ?? profiles[0] ?? defaultCreatorProfile;
+
+  const value = useMemo<CreatorContextValue>(
+    () => ({
+      profiles,
+      activeProfile,
+      activeProfileId: activeProfile.id,
+      setActiveProfileId,
+      updateActiveProfile: (updates) => {
+        setProfiles((current) =>
+          current.map((profile) =>
+            profile.id === activeProfile.id ? { ...profile, ...updates } : profile
+          )
+        );
+      },
+      addProfile: (name) => {
+        const trimmed = name.trim();
+
+        if (!trimmed) {
+          return;
+        }
+
+        const id = `${trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-${Date.now()}`;
+        const profile: CreatorProfile = {
+          id,
+          name: trimmed,
+          instagramHandle: `@${trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "")}`,
+          accountType: "Creator",
+          facebookPageLinked: false,
+          insightsPermissionReady: false,
+          status: "Setup needed"
+        };
+
+        setProfiles((current) => [...current, profile]);
+        setActiveProfileId(id);
+      }
+    }),
+    [activeProfile, profiles]
+  );
+
+  return <CreatorContext.Provider value={value}>{children}</CreatorContext.Provider>;
+}
+
+export function useCreator() {
+  const value = useContext(CreatorContext);
+
+  if (!value) {
+    throw new Error("useCreator must be used within a CreatorProvider");
+  }
+
+  return value;
+}

--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Link from "next/link";
+import { useCreator } from "@/components/creator-provider";
+
+export function Topbar() {
+  const { activeProfile } = useCreator();
+
+  return (
+    <header className="topbar">
+      <Link className="topbar__brand" href="/">
+        Maddie HQ
+      </Link>
+      <nav className="topbar__nav" aria-label="Main navigation">
+        <Link href="/">Home</Link>
+        <Link href="/insights">Insights</Link>
+        <Link href="/tracker">Tracker</Link>
+        <Link href="/conversion">Conversion</Link>
+        <Link href="/creator">Creator</Link>
+      </nav>
+      <div className="topbar__profile">
+        <span className="topbar__profile-name">{activeProfile.name}</span>
+        <span className="topbar__profile-handle">{activeProfile.instagramHandle}</span>
+      </div>
+    </header>
+  );
+}

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -20,6 +20,10 @@ export const defaultConversionInputs: ConversionInputs = {
   topSpenderAmount: 185
 };
 
+export function buildConversionStorageKey(creatorId: string) {
+  return `maddiehq:${creatorId}:conversion-inputs`;
+}
+
 export function formatWholeNumber(value: number) {
   return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value);
 }

--- a/lib/creator.ts
+++ b/lib/creator.ts
@@ -1,0 +1,21 @@
+export type InstagramAccountType = "Creator" | "Business";
+
+export type CreatorProfile = {
+  id: string;
+  name: string;
+  instagramHandle: string;
+  accountType: InstagramAccountType;
+  facebookPageLinked: boolean;
+  insightsPermissionReady: boolean;
+  status: "Setup needed" | "Ready to connect" | "Connected later";
+};
+
+export const defaultCreatorProfile: CreatorProfile = {
+  id: "maddie-default",
+  name: "Maddie",
+  instagramHandle: "@maddie",
+  accountType: "Creator",
+  facebookPageLinked: false,
+  insightsPermissionReady: false,
+  status: "Setup needed"
+};


### PR DESCRIPTION
## Summary
- add a local creator profile/account foundation
- scope saved conversion inputs to the active creator instead of generic browser storage
- add a creator setup room with Instagram connection prep fields
- add top-bar creator context and homepage entry point for the new foundation layer

## Verification
- checked /creator in the running app on localhost:3000
- checked homepage and topbar rendering for creator context
- ran PATH=/opt/homebrew/bin:/Users/madisynarmogida/.codex/tmp/arg0/codex-arg0mxFvd0:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Codex.app/Contents/Resources /opt/homebrew/bin/npm run lint

Closes #21