### PR TITLE
Turn homepage into a brainstorm logger and suggester

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ This log exists so the agent does not keep asking Maddie the same crash-course q
 - Authentication: taught on 2026-03-17.
 - Authorization: taught on 2026-03-17.
 - Encryption: taught on 2026-03-17.
+- State: taught on 2026-03-17.
 
 ## Execution Rules
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -322,6 +322,11 @@ h1 {
   gap: 24px;
 }
 
+.home-grid--compact {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 22px;
+}
+
 .home-card {
   display: flex;
   flex-direction: column;
@@ -376,6 +381,12 @@ h1 {
 
 .conversion-grid {
   grid-template-columns: 1.15fr 0.85fr;
+}
+
+.brainstorm-grid {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 24px;
 }
 
 .creator-grid {
@@ -740,6 +751,11 @@ li + li {
   font: inherit;
 }
 
+.input-card__field--textarea {
+  min-height: 180px;
+  resize: vertical;
+}
+
 .input-card__field:focus {
   outline: 2px solid rgba(182, 255, 39, 0.35);
   outline-offset: 2px;
@@ -755,6 +771,83 @@ li + li {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.brainstorm-panel,
+.brainstorm-form,
+.brainstorm-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.brainstorm-panel,
+.brainstorm-form {
+  gap: 18px;
+}
+
+.brainstorm-list {
+  gap: 14px;
+}
+
+.brainstorm-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.brainstorm-actions__hint {
+  margin: 0;
+  color: rgba(248, 255, 213, 0.72);
+  line-height: 1.5;
+}
+
+.brainstorm-entry,
+.brainstorm-empty {
+  padding: 18px;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.brainstorm-entry__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.brainstorm-entry__tag {
+  display: inline-flex;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 79, 163, 0.14);
+  color: var(--pink-soft);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.brainstorm-entry__remove {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(248, 255, 213, 0.72);
+  font: inherit;
+}
+
+.brainstorm-entry p,
+.brainstorm-empty p {
+  margin: 0;
+  color: rgba(248, 255, 213, 0.82);
+  line-height: 1.6;
+}
+
+.brainstorm-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .creator-add {
@@ -1056,6 +1149,7 @@ li + li {
   }
 
   .hero,
+  .brainstorm-grid,
   .home-grid,
   .overview-grid,
   .platform-grid,
@@ -1074,6 +1168,11 @@ li + li {
   }
 
   .input-toolbar {
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .brainstorm-actions {
     flex-direction: column;
     align-items: start;
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,15 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import {
+  brainstormCategories,
+  buildBrainstormSuggestions,
+  type BrainstormCategory,
+  type BrainstormEntry
+} from "@/lib/brainstorm";
+
+const STORAGE_KEY = "maddiehq:brainstorms";
 
 const homeCards = [
   {
@@ -32,43 +43,218 @@ const homeCards = [
 ];
 
 export default function HomePage() {
+  const [draft, setDraft] = useState("");
+  const [category, setCategory] = useState<BrainstormCategory>("Content idea");
+  const [entries, setEntries] = useState<BrainstormEntry[]>([]);
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!saved) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as BrainstormEntry[];
+      if (Array.isArray(parsed)) {
+        setEntries(parsed);
+      }
+    } catch {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  }, [entries]);
+
+  const suggestions = useMemo(() => buildBrainstormSuggestions(draft, category), [category, draft]);
+
+  function saveEntry() {
+    const trimmed = draft.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    const nextEntry: BrainstormEntry = {
+      id: `${Date.now()}`,
+      text: trimmed,
+      category,
+      createdAt: new Date().toISOString()
+    };
+
+    setEntries((current) => [nextEntry, ...current].slice(0, 8));
+    setDraft("");
+  }
+
+  function removeEntry(id: string) {
+    setEntries((current) => current.filter((entry) => entry.id !== id));
+  }
+
   return (
     <main className="page">
       <section className="hero panel">
         <div>
           <p className="eyebrow">Maddie HQ</p>
-          <h1>An Instagram creator home base for the parts of your workflow you want under control.</h1>
+          <h1>Use the homepage like a brainstorm desk, not just a hallway.</h1>
           <p className="lede">
-            This site is now organized like a real app. Start from the homepage,
-            jump into the Instagram tools you want, and grow it over time instead
-            of cramming everything into one screen.
+            Drop rough ideas here while they are still fresh, let the app suggest what
+            kind of move it could become, then jump into the room that helps you act on it.
           </p>
         </div>
         <div className="hero__note">
-          <span className="hero__badge">Instagram-first</span>
+          <span className="hero__badge">Brainstorm mode</span>
           <p>
-            Right now your Instagram Insights dashboard, Tracker room, and Conversion
-            room are ready. More creator tools can plug into this same structure as you decide what you need.
+            This homepage now acts like a quick capture notebook with lightweight
+            guidance, while still keeping your main rooms one tap away.
           </p>
-          <Link className="hero__cta" href="/insights">
-            Open Instagram Insights
+          <Link className="hero__cta" href="/tracker">
+            Open Tracker
           </Link>
         </div>
       </section>
 
-      <section className="home-grid">
-        {homeCards.map((card) => (
-          <article className="panel home-card" key={card.title}>
-            <div className="home-card__header">
-              <p className="eyebrow">{card.status}</p>
-              <h2>{card.title}</h2>
+      <section className="brainstorm-grid">
+        <article className="panel brainstorm-panel">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Brain Dump</p>
+              <h2>Log the idea before it disappears.</h2>
             </div>
-            <p>{card.description}</p>
-            <Link className="home-card__link" href={card.href}>
-              Open tool
-            </Link>
-          </article>
-        ))}
+            <span className="suggestions-card__tag">Saved in this browser</span>
+          </div>
+
+          <div className="brainstorm-form">
+            <label className="input-card">
+              <span className="input-card__label">Idea Type</span>
+              <select
+                className="input-card__field"
+                value={category}
+                onChange={(event) => setCategory(event.target.value as BrainstormCategory)}
+              >
+                {brainstormCategories.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="input-card">
+              <span className="input-card__label">Messy First Draft</span>
+              <textarea
+                className="input-card__field input-card__field--textarea"
+                placeholder="Dump the raw thought here. It does not need to be polished."
+                value={draft}
+                onChange={(event) => setDraft(event.target.value)}
+              />
+              <span className="input-card__help">
+                This is for half-formed thoughts, content hooks, promo angles, or “what if”
+                ideas you want to revisit later.
+              </span>
+            </label>
+
+            <div className="brainstorm-actions">
+              <button className="hero__cta" type="button" onClick={saveEntry}>
+                Save brainstorm
+              </button>
+              <p className="brainstorm-actions__hint">
+                The latest 8 brainstorms stay saved on this device.
+              </p>
+            </div>
+          </div>
+        </article>
+
+        <article className="panel brainstorm-panel">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Smart Nudge</p>
+              <h2>What this idea might turn into next.</h2>
+            </div>
+            <span className="suggestions-card__tag">Suggestion preview</span>
+          </div>
+
+          <div className="suggestion-grid">
+            {suggestions.map((suggestion) => (
+              <article className="suggestion-card" key={suggestion.title}>
+                <div className="suggestion-card__header">
+                  <div>
+                    <p className="eyebrow">{suggestion.label}</p>
+                    <h2>{suggestion.title}</h2>
+                  </div>
+                  <span className="suggestion-card__confidence">{suggestion.confidence}</span>
+                </div>
+                <p className="suggestion-card__action">{suggestion.action}</p>
+                <div className="suggestion-card__footer">
+                  <p className="suggestion-card__label">Why this helps</p>
+                  <p className="suggestion-card__why">{suggestion.reason}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="bottom-grid">
+        <article className="panel">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Saved Brainstorms</p>
+              <h2>Your recent raw ideas.</h2>
+            </div>
+            <span className="suggestions-card__tag">{entries.length} saved</span>
+          </div>
+
+          <div className="brainstorm-list">
+            {entries.length ? (
+              entries.map((entry) => (
+                <article className="brainstorm-entry" key={entry.id}>
+                  <div className="brainstorm-entry__top">
+                    <span className="brainstorm-entry__tag">{entry.category}</span>
+                    <button
+                      className="brainstorm-entry__remove"
+                      type="button"
+                      onClick={() => removeEntry(entry.id)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <p>{entry.text}</p>
+                </article>
+              ))
+            ) : (
+              <div className="brainstorm-empty">
+                <p>No brainstorms saved yet.</p>
+                <p>Start with a messy idea above and the homepage will keep it here.</p>
+              </div>
+            )}
+          </div>
+        </article>
+
+        <article className="panel breakdown-card">
+          <p className="eyebrow">Launchpad</p>
+          <h2>When an idea gets sharper, move it into the right room.</h2>
+          <p>
+            Use the brainstorm desk to capture thoughts fast. Then use Insights when the
+            question is performance, Tracker when the question is execution, and Conversion
+            when the question is whether attention is turning into subscribers and money.
+          </p>
+          <section className="home-grid home-grid--compact">
+            {homeCards.map((card) => (
+              <article className="panel home-card" key={card.title}>
+                <div className="home-card__header">
+                  <p className="eyebrow">{card.status}</p>
+                  <h2>{card.title}</h2>
+                </div>
+                <p>{card.description}</p>
+                <Link className="home-card__link" href={card.href}>
+                  Open tool
+                </Link>
+              </article>
+            ))}
+          </section>
+        </article>
       </section>
     </main>
   );

--- a/lib/brainstorm.ts
+++ b/lib/brainstorm.ts
@@ -1,0 +1,97 @@
+export const brainstormCategories = [
+  "Content idea",
+  "Caption idea",
+  "Promotion idea",
+  "OF idea"
+] as const;
+
+export type BrainstormCategory = (typeof brainstormCategories)[number];
+
+export type BrainstormEntry = {
+  id: string;
+  text: string;
+  category: BrainstormCategory;
+  createdAt: string;
+};
+
+type BrainstormSuggestion = {
+  label: string;
+  title: string;
+  action: string;
+  reason: string;
+  confidence: string;
+};
+
+function summarizeIdea(text: string) {
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    return "You have not dropped an idea in yet, so the app is showing starter guidance.";
+  }
+
+  return trimmed.length > 120 ? `${trimmed.slice(0, 117)}...` : trimmed;
+}
+
+export function buildBrainstormSuggestions(
+  text: string,
+  category: BrainstormCategory
+): BrainstormSuggestion[] {
+  const summary = summarizeIdea(text);
+
+  const categorySuggestion: Record<BrainstormCategory, BrainstormSuggestion> = {
+    "Content idea": {
+      label: "Shape it",
+      title: "Turn this into a reel concept",
+      action: `Treat "${summary}" like the hook seed. Write a strong first line, define the visual, and decide what reaction you want in the first three seconds.`,
+      reason:
+        "Content ideas get stronger when you quickly translate the raw thought into a hook, a shot idea, and a clear reaction target.",
+      confidence: "Best next move"
+    },
+    "Caption idea": {
+      label: "Refine it",
+      title: "Test the tone and CTA",
+      action: `Use "${summary}" as a caption draft, then create two versions: one flirtier and one more direct, each with a clear action you want the viewer to take.`,
+      reason:
+        "Captions work better when the tone matches the post and the call to action is intentional instead of implied.",
+      confidence: "High fit"
+    },
+    "Promotion idea": {
+      label: "Pressure test it",
+      title: "Decide where the promotion lives",
+      action: `Take "${summary}" and decide whether it belongs in a reel, a story sequence, or a bio-link push so the message matches the placement.`,
+      reason:
+        "Promotions usually fail when the idea is fine but the placement and traffic path are not planned.",
+      confidence: "High fit"
+    },
+    "OF idea": {
+      label: "Connect it",
+      title: "Tie the idea to conversion",
+      action: `Look at "${summary}" and ask what behavior it should drive: profile visits, OF page views, new subs, or more spending from current subs.`,
+      reason:
+        "OF-side ideas get more useful when they are connected to a business outcome instead of staying as a vague concept.",
+      confidence: "Best next move"
+    }
+  };
+
+  return [
+    categorySuggestion[category],
+    {
+      label: "Organize it",
+      title: "Choose the room this belongs in",
+      action:
+        "If this idea is about performance, move it into Insights. If it is about execution, move it into Tracker. If it is about money or subscriber behavior, move it into Conversion.",
+      reason:
+        "The app gets more useful when each idea ends up in the room built to help with that kind of decision.",
+      confidence: "Always useful"
+    },
+    {
+      label: "Make it concrete",
+      title: "Add one measurable outcome",
+      action:
+        "Before acting on the idea, write one number or signal that would tell you it worked, like reel views, profile visits, OF page views, or new subs.",
+      reason:
+        "Attaching a measurable outcome makes the idea easier to judge later instead of relying on vibes alone.",
+      confidence: "Strong habit"
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- turn the homepage into a saved brainstorm desk instead of a static lobby
- add suggestion logic that nudges rough ideas toward a next move
- keep the homepage as a launchpad into the other rooms

Closes #26