### PR TITLE
Add development demo login shortcut

### DIFF
--- a/app/api/dev/demo-user/route.ts
+++ b/app/api/dev/demo-user/route.ts
@@ -1,0 +1,33 @@
+import bcrypt from "bcryptjs";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const DEMO_EMAIL = "maddie@example.com";
+const DEMO_PASSWORD = "sunrise123";
+const DEMO_NAME = "Maddie Test";
+
+export async function POST() {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ message: "Not available in production." }, { status: 404 });
+  }
+
+  const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 10);
+
+  const user = await prisma.user.upsert({
+    where: { email: DEMO_EMAIL },
+    update: {
+      name: DEMO_NAME,
+      passwordHash
+    },
+    create: {
+      name: DEMO_NAME,
+      email: DEMO_EMAIL,
+      passwordHash
+    }
+  });
+
+  return NextResponse.json({
+    email: user.email,
+    password: DEMO_PASSWORD
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -497,7 +497,23 @@ h1 {
   cursor: pointer;
 }
 
+.auth-form__demo {
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 79, 163, 0.12);
+  color: var(--pink-soft);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .auth-form__submit:disabled {
+  opacity: 0.68;
+  cursor: wait;
+}
+
+.auth-form__demo:disabled {
   opacity: 0.68;
   cursor: wait;
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,6 +12,8 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [pending, setPending] = useState(false);
+  const [demoPending, setDemoPending] = useState(false);
+  const isDevelopment = process.env.NODE_ENV !== "production";
 
   useEffect(() => {
     if (status === "authenticated") {
@@ -35,6 +37,44 @@ export default function LoginPage() {
 
     if (result?.error) {
       setError("That login did not work. Check your email and password.");
+      return;
+    }
+
+    router.replace("/");
+    router.refresh();
+  }
+
+  async function handleDemoLogin() {
+    setDemoPending(true);
+    setError("");
+
+    const seedResponse = await fetch("/api/dev/demo-user", {
+      method: "POST"
+    });
+
+    const payload = (await seedResponse.json()) as {
+      email?: string;
+      password?: string;
+      message?: string;
+    };
+
+    if (!seedResponse.ok || !payload.email || !payload.password) {
+      setDemoPending(false);
+      setError(payload.message ?? "Demo login setup failed.");
+      return;
+    }
+
+    const result = await signIn("credentials", {
+      email: payload.email,
+      password: payload.password,
+      redirect: false,
+      callbackUrl: "/"
+    });
+
+    setDemoPending(false);
+
+    if (result?.error) {
+      setError("Demo login failed.");
       return;
     }
 
@@ -80,6 +120,17 @@ export default function LoginPage() {
           <button className="hero__cta auth-form__submit" disabled={pending} type="submit">
             {pending ? "Logging in..." : "Log In"}
           </button>
+
+          {isDevelopment ? (
+            <button
+              className="auth-form__demo"
+              disabled={demoPending}
+              type="button"
+              onClick={handleDemoLogin}
+            >
+              {demoPending ? "Opening demo account..." : "Use Demo Account"}
+            </button>
+          ) : null}
         </form>
 
         <p className="auth-form__switch">

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,5 +23,5 @@ export default withAuth(
 );
 
 export const config = {
-  matcher: ["/((?!api/auth|api/register|_next/static|_next/image|favicon.ico).*)"]
+  matcher: ["/((?!api/auth|api/register|api/dev/demo-user|_next/static|_next/image|favicon.ico).*)"]
 };


### PR DESCRIPTION
## Summary
- add a development-only route that seeds a demo user if needed
- add a one-click demo login button on the login page
- keep production auth behavior unchanged

## Verification
- lint passes
- /login loads
- POST /api/dev/demo-user returns demo credentials in development

Closes #36