### PR TITLE
Relax auth enforcement in development

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,10 @@ export default withAuth(
   {
     callbacks: {
       authorized: ({ req, token }) => {
+        if (process.env.NODE_ENV !== "production") {
+          return true;
+        }
+
         const pathname = req.nextUrl.pathname;
 
         if (publicPaths.some((path) => pathname === path || pathname.startsWith(`${path}/`))) {


### PR DESCRIPTION
## Summary
- keep the auth foundation in place
- stop blocking local development behind login on every route
- leave login and signup available for auth testing

## Verification
- lint passes
- / now returns 200 in development
- /login still returns 200

Closes #38