### PR TITLE
Build assistant memory foundation

### DIFF
--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useCreator } from "@/components/creator-provider";
+import {
+  assistantFocusOptions,
+  assistantToneOptions,
+  buildAssistantMemoryStorageKey,
+  buildDefaultAssistantMemory,
+  type AssistantMemory
+} from "@/lib/assistant-memory";
 
 export default function CreatorPage() {
   const {
@@ -13,6 +20,39 @@ export default function CreatorPage() {
     updateActiveProfile
   } = useCreator();
   const [newProfileName, setNewProfileName] = useState("");
+  const [assistantMemory, setAssistantMemory] = useState<AssistantMemory>(() =>
+    buildDefaultAssistantMemory(activeProfile.name)
+  );
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(buildAssistantMemoryStorageKey(activeProfile.id));
+
+    if (!saved) {
+      setAssistantMemory(buildDefaultAssistantMemory(activeProfile.name));
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as Partial<AssistantMemory>;
+      setAssistantMemory({
+        ...buildDefaultAssistantMemory(activeProfile.name),
+        ...parsed
+      });
+    } catch {
+      setAssistantMemory(buildDefaultAssistantMemory(activeProfile.name));
+    }
+  }, [activeProfile.id, activeProfile.name]);
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      buildAssistantMemoryStorageKey(activeProfile.id),
+      JSON.stringify(assistantMemory)
+    );
+  }, [activeProfile.id, assistantMemory]);
+
+  function updateAssistantMemory(updates: Partial<AssistantMemory>) {
+    setAssistantMemory((current) => ({ ...current, ...updates }));
+  }
 
   return (
     <main className="page">
@@ -183,6 +223,129 @@ export default function CreatorPage() {
           </p>
         </article>
 
+        <article className="panel assistant-settings">
+          <div className="suggestions-card__header">
+            <p className="eyebrow">Assistant Memory</p>
+            <span className="suggestions-card__tag">What your assistant remembers</span>
+          </div>
+          <div className="creator-form">
+            <label className="input-card">
+              <span className="input-card__label">Assistant Name</span>
+              <input
+                className="input-card__field"
+                value={assistantMemory.assistantName}
+                onChange={(event) =>
+                  updateAssistantMemory({ assistantName: event.target.value })
+                }
+              />
+              <span className="input-card__help">
+                This is the persona label the homepage assistant will use.
+              </span>
+            </label>
+
+            <div className="input-grid">
+              <label className="input-card">
+                <span className="input-card__label">Tone</span>
+                <select
+                  className="input-card__field"
+                  value={assistantMemory.tone}
+                  onChange={(event) =>
+                    updateAssistantMemory({
+                      tone: event.target.value as AssistantMemory["tone"]
+                    })
+                  }
+                >
+                  {assistantToneOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="input-card">
+                <span className="input-card__label">Focus Mode</span>
+                <select
+                  className="input-card__field"
+                  value={assistantMemory.focus}
+                  onChange={(event) =>
+                    updateAssistantMemory({
+                      focus: event.target.value as AssistantMemory["focus"]
+                    })
+                  }
+                >
+                  {assistantFocusOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <label className="input-card">
+              <span className="input-card__label">Main Goal</span>
+              <textarea
+                className="input-card__field input-card__field--short-textarea"
+                value={assistantMemory.mainGoal}
+                onChange={(event) =>
+                  updateAssistantMemory({ mainGoal: event.target.value })
+                }
+              />
+            </label>
+
+            <label className="input-card">
+              <span className="input-card__label">Current Priority</span>
+              <textarea
+                className="input-card__field input-card__field--short-textarea"
+                value={assistantMemory.currentPriority}
+                onChange={(event) =>
+                  updateAssistantMemory({ currentPriority: event.target.value })
+                }
+              />
+            </label>
+
+            <label className="input-card">
+              <span className="input-card__label">Success Signal</span>
+              <textarea
+                className="input-card__field input-card__field--short-textarea"
+                value={assistantMemory.successSignal}
+                onChange={(event) =>
+                  updateAssistantMemory({ successSignal: event.target.value })
+                }
+              />
+            </label>
+
+            <label className="input-card">
+              <span className="input-card__label">Manager Notes</span>
+              <textarea
+                className="input-card__field input-card__field--short-textarea"
+                value={assistantMemory.managerNotes}
+                onChange={(event) =>
+                  updateAssistantMemory({ managerNotes: event.target.value })
+                }
+              />
+            </label>
+
+            <label className="input-card">
+              <span className="input-card__label">Creator Context</span>
+              <textarea
+                className="input-card__field input-card__field--short-textarea"
+                value={assistantMemory.creatorContext}
+                onChange={(event) =>
+                  updateAssistantMemory({ creatorContext: event.target.value })
+                }
+              />
+              <span className="input-card__help">
+                Use this for things like your style, working preferences, what confuses you,
+                or what kind of support helps most.
+              </span>
+            </label>
+          </div>
+        </article>
+      </section>
+
+      <section className="bottom-grid">
         <article className="panel suggestions-card">
           <div className="suggestions-card__header">
             <p className="eyebrow">Safety Reminder</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -397,6 +397,14 @@ h1 {
   line-height: 1.65;
 }
 
+.assistant-card__memory-note {
+  margin: 16px 0 0;
+  color: rgba(248, 255, 213, 0.7);
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .assistant-card__note {
   display: flex;
   flex-direction: column;
@@ -807,6 +815,11 @@ li + li {
 
 .input-card__field--textarea {
   min-height: 180px;
+  resize: vertical;
+}
+
+.input-card__field--short-textarea {
+  min-height: 110px;
   resize: vertical;
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useCreator } from "@/components/creator-provider";
+import {
+  buildAssistantMemoryStorageKey,
+  buildDefaultAssistantMemory,
+  type AssistantMemory
+} from "@/lib/assistant-memory";
 import { buildAssistantBrief } from "@/lib/assistant";
 import {
   brainstormCategories,
@@ -23,6 +28,9 @@ export default function HomePage() {
   const [category, setCategory] = useState<BrainstormCategory>("Content idea");
   const [entries, setEntries] = useState<BrainstormEntry[]>([]);
   const [conversionInputs, setConversionInputs] = useState<ConversionInputs | null>(null);
+  const [assistantMemory, setAssistantMemory] = useState<AssistantMemory>(() =>
+    buildDefaultAssistantMemory(activeProfile.name)
+  );
 
   useEffect(() => {
     const saved = window.localStorage.getItem(STORAGE_KEY);
@@ -61,6 +69,25 @@ export default function HomePage() {
     }
   }, [activeProfile.id]);
 
+  useEffect(() => {
+    const saved = window.localStorage.getItem(buildAssistantMemoryStorageKey(activeProfile.id));
+
+    if (!saved) {
+      setAssistantMemory(buildDefaultAssistantMemory(activeProfile.name));
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as Partial<AssistantMemory>;
+      setAssistantMemory({
+        ...buildDefaultAssistantMemory(activeProfile.name),
+        ...parsed
+      });
+    } catch {
+      setAssistantMemory(buildDefaultAssistantMemory(activeProfile.name));
+    }
+  }, [activeProfile.id, activeProfile.name]);
+
   const suggestions = useMemo(() => buildBrainstormSuggestions(draft, category), [category, draft]);
   const assistantBrief = useMemo(
     () =>
@@ -69,9 +96,10 @@ export default function HomePage() {
         draft,
         category,
         entries,
-        conversionInputs
+        conversionInputs,
+        memory: assistantMemory
       }),
-    [activeProfile.name, category, conversionInputs, draft, entries]
+    [activeProfile.name, assistantMemory, category, conversionInputs, draft, entries]
   );
 
   function saveEntry() {
@@ -121,6 +149,9 @@ export default function HomePage() {
           <h2>{assistantBrief.title}</h2>
           <p>
             {assistantBrief.summary}
+          </p>
+          <p className="assistant-card__memory-note">
+            Saved mode: {assistantMemory.tone} · {assistantMemory.focus} focus
           </p>
         </div>
         <div className="assistant-card__note">

--- a/lib/assistant-memory.ts
+++ b/lib/assistant-memory.ts
@@ -1,0 +1,46 @@
+export const assistantToneOptions = [
+  "Soft coach",
+  "Direct operator",
+  "Warm manager",
+  "Hype girl"
+] as const;
+
+export const assistantFocusOptions = [
+  "Balanced",
+  "Growth",
+  "Revenue",
+  "Execution"
+] as const;
+
+export type AssistantTone = (typeof assistantToneOptions)[number];
+export type AssistantFocus = (typeof assistantFocusOptions)[number];
+
+export type AssistantMemory = {
+  assistantName: string;
+  tone: AssistantTone;
+  focus: AssistantFocus;
+  mainGoal: string;
+  currentPriority: string;
+  successSignal: string;
+  managerNotes: string;
+  creatorContext: string;
+};
+
+export function buildAssistantMemoryStorageKey(creatorId: string) {
+  return `maddiehq:${creatorId}:assistant-memory`;
+}
+
+export function buildDefaultAssistantMemory(profileName: string): AssistantMemory {
+  return {
+    assistantName: `${profileName}'s assistant`,
+    tone: "Warm manager",
+    focus: "Balanced",
+    mainGoal: "Turn Instagram traffic into stronger OF conversion and steadier revenue.",
+    currentPriority: "Figure out what kind of reels are bringing the right traffic, not just a lot of traffic.",
+    successSignal: "More OF page views, stronger sub conversion, and more repeat patterns I can trust.",
+    managerNotes:
+      "Keep an eye on the reel hooks that bring people over, and track whether the OF handoff is getting stronger.",
+    creatorContext:
+      "Fast learner, creator-first, wants the app to explain what matters instead of dumping confusing numbers."
+  };
+}

--- a/lib/assistant.ts
+++ b/lib/assistant.ts
@@ -1,3 +1,4 @@
+import type { AssistantMemory } from "@/lib/assistant-memory";
 import { buildConversionSummary, type ConversionInputs } from "@/lib/conversion";
 import type { BrainstormCategory, BrainstormEntry } from "@/lib/brainstorm";
 
@@ -17,6 +18,7 @@ type BuildAssistantBriefArgs = {
   category: BrainstormCategory;
   entries: BrainstormEntry[];
   conversionInputs: ConversionInputs | null;
+  memory: AssistantMemory;
 };
 
 function getCategoryLeader(entries: BrainstormEntry[]) {
@@ -39,20 +41,38 @@ function summarizeDraft(draft: string) {
   return trimmed.length > 90 ? `${trimmed.slice(0, 87)}...` : trimmed;
 }
 
-function buildDefaultBrief(profileName: string): AssistantBrief {
+function summarizeNote(text: string) {
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed.length > 110 ? `${trimmed.slice(0, 107)}...` : trimmed;
+}
+
+function buildDefaultBrief(profileName: string, memory: AssistantMemory): AssistantBrief {
   return {
-    eyebrow: "Desk Assistant",
-    title: `Morning ${profileName}, start by catching one useful thought.`,
+    eyebrow: memory.assistantName,
+    title: `Morning ${profileName}, let’s start with what matters most today.`,
     summary:
+      memory.currentPriority ||
       "The fastest way to make this app useful is to feed it something real. Drop one messy idea, one OF observation, or one thing your managers keep saying.",
-    focusLabel: "Best first move",
-    focusValue: "Log one real idea",
+    focusLabel: "Primary mission",
+    focusValue: memory.mainGoal || "Log one real idea",
     focusDetail:
+      memory.successSignal ||
       "Once there is real input, the assistant can stop giving generic advice and start acting more like a manager.",
     actions: [
+      `Work in a ${memory.tone.toLowerCase()} mode: clear, practical, and focused on ${memory.focus.toLowerCase()} decisions.`,
       "Write the rough idea exactly how it sounds in your head. Do not polish it first.",
       "Pick the closest idea type so the app knows what kind of help to give.",
-      "If you already know yesterday's OF numbers, update Conversion after this."
+      memory.focus === "Revenue"
+        ? "If you already know yesterday's OF numbers, update Conversion first so the assistant can ground itself in business reality."
+        : "If you already know yesterday's OF numbers, update Conversion after this.",
+      memory.managerNotes.trim()
+        ? `Manager note to keep in mind: ${summarizeNote(memory.managerNotes)}`
+        : "Keep one manager note or business reminder saved here so the assistant can stay aligned."
     ]
   };
 }
@@ -62,31 +82,35 @@ export function buildAssistantBrief({
   draft,
   category,
   entries,
-  conversionInputs
+  conversionInputs,
+  memory
 }: BuildAssistantBriefArgs): AssistantBrief {
   if (!entries.length && !draft.trim()) {
-    return buildDefaultBrief(profileName);
+    return buildDefaultBrief(profileName, memory);
   }
 
   if (draft.trim()) {
     const draftSummary = summarizeDraft(draft);
 
     return {
-      eyebrow: "Desk Assistant",
+      eyebrow: memory.assistantName,
       title: "This idea is ready for one sharper next step.",
-      summary: `Your current ${category.toLowerCase()} draft is "${draftSummary}". It does not need to be finished. It just needs to be shaped enough that you know what room or task it belongs to next.`,
+      summary: `Your current ${category.toLowerCase()} draft is "${draftSummary}". It does not need to be finished. It just needs to be shaped enough that you know what room or task it belongs to next. Right now your saved priority is: ${memory.currentPriority.toLowerCase()}`,
       focusLabel: "Current focus",
       focusValue: `Shape this ${category.toLowerCase()}`,
       focusDetail:
         category === "OF idea"
           ? "OF-side thoughts get more powerful when you tie them to page views, subs, or spending instead of leaving them vague."
-          : "The job now is to turn the raw thought into something you can test, track, or hand off to execution.",
+          : `The job now is to turn the raw thought into something you can test, track, or hand off to execution in a ${memory.tone.toLowerCase()} way.`,
       actions: [
         "Save the idea so it becomes part of your working stack instead of disappearing.",
         "Add one success signal, like reel views, OF page views, or new subscribers.",
         category === "Content idea"
           ? "If this becomes a reel, move it into Tracker next so it can turn into an actual post."
-          : "Once saved, decide whether it belongs in Insights, Tracker, or Conversion."
+          : "Once saved, decide whether it belongs in Insights, Tracker, or Conversion.",
+        memory.managerNotes.trim()
+          ? `Stay aligned with this note: ${summarizeNote(memory.managerNotes)}`
+          : "Use Creator settings to save the kind of reminder your assistant should keep repeating."
       ]
     };
   }
@@ -102,38 +126,41 @@ export function buildAssistantBrief({
     const conversionRateValue = Number.parseFloat(conversionRate);
 
     return {
-      eyebrow: "Desk Assistant",
+      eyebrow: memory.assistantName,
       title:
         conversionRateValue >= 3
           ? "Your OF handoff looks healthy enough to start optimizing quality."
           : "Your OF handoff still looks like the main pressure point right now.",
       summary:
         conversionRateValue >= 3
-          ? `You are converting about ${conversionRate} of OF page views into new subs. That means the next leverage is probably quality of traffic, subscriber behavior, and spend depth.`
+          ? `You are converting about ${conversionRate} of OF page views into new subs. That means the next leverage is probably quality of traffic, subscriber behavior, and spend depth. Your saved goal is still: ${memory.mainGoal.toLowerCase()}`
           : `You are currently around ${conversionRate} from OF page views to new subs, based on ${pageViews} page views and ${newSubs} new subs. That is below the 3-4% target you mentioned, so the bridge into OF is still the most important thing to study.`,
       focusLabel: "Business focus",
       focusValue: `${conversionRate} OF conversion`,
       focusDetail:
         conversionRateValue >= 3
-          ? "Now that the page is converting decently, the assistant should start caring more about who is spending and which traffic converts best."
+          ? `Now that the page is converting decently, the assistant should start caring more about who is spending and which traffic converts best for ${memory.focus.toLowerCase()} growth.`
           : "The app should keep helping you compare reel traffic, profile curiosity, and OF page setup until that handoff gets stronger.",
       actions: [
         "Look at which reel or promo angle produced the latest OF page views.",
         latestEntry
           ? `Check whether your latest saved idea (${latestEntry.category.toLowerCase()}) supports getting better traffic, not just more traffic.`
           : "Add a note about what kind of reel or promo angle sent that traffic over.",
-        "Keep logging OF page views and new subscribers together so this number stays honest."
+        "Keep logging OF page views and new subscribers together so this number stays honest.",
+        memory.managerNotes.trim()
+          ? `Do not lose this operating note: ${summarizeNote(memory.managerNotes)}`
+          : "Save a manager-style note in Creator settings so the assistant keeps your strategy in view."
       ]
     };
   }
 
   return {
-    eyebrow: "Desk Assistant",
+    eyebrow: memory.assistantName,
     title: "You have idea momentum. Now connect it to the business side.",
     summary:
       latestEntry.category === "OF idea"
         ? "You already have OF-side thinking saved, which is good. The next layer is making sure those thoughts connect to actual numbers in Conversion."
-        : `Your latest saved brainstorm is a ${latestEntry.category.toLowerCase()}. That tells me the creative side is moving. The next step is making sure the business side keeps up.`,
+        : `Your latest saved brainstorm is a ${latestEntry.category.toLowerCase()}. That tells me the creative side is moving. The next step is making sure the business side keeps up with your bigger goal: ${memory.mainGoal.toLowerCase()}`,
     focusLabel: "Pattern I notice",
     focusValue: categoryLeader
       ? `${categoryLeader[1]} ${categoryLeader[0].toLowerCase()}s saved`
@@ -141,11 +168,16 @@ export function buildAssistantBrief({
     focusDetail:
       categoryLeader && categoryLeader[1] >= 3
         ? `Most of your recent notes are ${categoryLeader[0].toLowerCase()}s, so it may be time to balance that with either execution in Tracker or business review in Conversion.`
-        : "You have enough saved context now that the homepage can start acting more like a working desk instead of a blank page.",
+        : `You have enough saved context now that the homepage can start acting more like ${memory.assistantName.toLowerCase()} and less like a blank page.`,
     actions: [
       `Review your latest note and ask what number would prove it worked.`,
-      "Open Conversion and fill in real OF numbers if you have them, because that gives the assistant a business reality check.",
-      "If one idea looks strong, move it into Tracker so it becomes a task instead of a pile of notes."
+      memory.focus === "Execution"
+        ? "Move the strongest idea into Tracker quickly so it turns into a real task."
+        : "Open Conversion and fill in real OF numbers if you have them, because that gives the assistant a business reality check.",
+      "If one idea looks strong, move it into Tracker so it becomes a task instead of a pile of notes.",
+      memory.creatorContext.trim()
+        ? `Creator context I am holding: ${summarizeNote(memory.creatorContext)}`
+        : "Add creator context in the profile room so the assistant learns how you like to work."
     ]
   };
 }


### PR DESCRIPTION
Closes #46\n\n## Summary\n- add a per-creator assistant memory model with saved tone, focus, goals, and notes\n- wire the homepage assistant to use saved memory alongside brainstorm and conversion context\n- add editor controls for the assistant memory in the creator room\n\n## Verification\n- npm run lint\n- curl -I http://localhost:3000/\n- curl -I http://localhost:3000/creator