### PR TITLE
Build assistant room and event memory foundation

### DIFF
--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useCreator } from "@/components/creator-provider";
+import {
+  buildAssistantOpeningMessages,
+  buildAssistantReply,
+  type AssistantChatMessage
+} from "@/lib/assistant-chat";
+import {
+  appendAssistantEvent,
+  readAssistantEvents,
+  type AssistantEvent
+} from "@/lib/assistant-events";
+import {
+  buildAssistantMemoryStorageKey,
+  buildDefaultAssistantMemory,
+  type AssistantMemory
+} from "@/lib/assistant-memory";
+import {
+  buildConversionStorageKey,
+  defaultConversionInputs,
+  type ConversionInputs
+} from "@/lib/conversion";
+
+const CHAT_STORAGE_PREFIX = "maddiehq:assistant-chat";
+
+function buildChatStorageKey(creatorId: string) {
+  return `${CHAT_STORAGE_PREFIX}:${creatorId}`;
+}
+
+export default function AssistantPage() {
+  const { activeProfile } = useCreator();
+  const [memory, setMemory] = useState<AssistantMemory>(() =>
+    buildDefaultAssistantMemory(activeProfile.name)
+  );
+  const [events, setEvents] = useState<AssistantEvent[]>([]);
+  const [conversionInputs, setConversionInputs] = useState<ConversionInputs | null>(null);
+  const [messages, setMessages] = useState<AssistantChatMessage[]>([]);
+  const [draft, setDraft] = useState("");
+
+  const chatStorageKey = useMemo(() => buildChatStorageKey(activeProfile.id), [activeProfile.id]);
+
+  useEffect(() => {
+    setMessages([]);
+  }, [chatStorageKey]);
+
+  useEffect(() => {
+    const savedMemory = window.localStorage.getItem(buildAssistantMemoryStorageKey(activeProfile.id));
+
+    if (savedMemory) {
+      try {
+        setMemory({
+          ...buildDefaultAssistantMemory(activeProfile.name),
+          ...(JSON.parse(savedMemory) as Partial<AssistantMemory>)
+        });
+      } catch {
+        setMemory(buildDefaultAssistantMemory(activeProfile.name));
+      }
+    } else {
+      setMemory(buildDefaultAssistantMemory(activeProfile.name));
+    }
+
+    setEvents(readAssistantEvents(activeProfile.id));
+
+    const savedConversion = window.localStorage.getItem(buildConversionStorageKey(activeProfile.id));
+    if (savedConversion) {
+      try {
+        setConversionInputs({
+          ...defaultConversionInputs,
+          ...(JSON.parse(savedConversion) as Partial<ConversionInputs>)
+        });
+      } catch {
+        setConversionInputs(null);
+      }
+    } else {
+      setConversionInputs(null);
+    }
+  }, [activeProfile.id, activeProfile.name]);
+
+  useEffect(() => {
+    const savedChat = window.localStorage.getItem(chatStorageKey);
+
+    if (savedChat) {
+      try {
+        const parsed = JSON.parse(savedChat) as AssistantChatMessage[];
+        if (Array.isArray(parsed) && parsed.length) {
+          setMessages(parsed);
+          return;
+        }
+      } catch {
+        window.localStorage.removeItem(chatStorageKey);
+      }
+    }
+
+    setMessages((current) =>
+      current.length ? current : buildAssistantOpeningMessages(memory, events, conversionInputs)
+    );
+  }, [chatStorageKey, conversionInputs, events, memory]);
+
+  useEffect(() => {
+    if (!messages.length) {
+      return;
+    }
+
+    window.localStorage.setItem(chatStorageKey, JSON.stringify(messages.slice(-18)));
+  }, [chatStorageKey, messages]);
+
+  function sendMessage() {
+    const trimmed = draft.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    const userMessage: AssistantChatMessage = {
+      id: `${Date.now()}-user`,
+      role: "user",
+      text: trimmed
+    };
+
+    const assistantMessage: AssistantChatMessage = {
+      id: `${Date.now()}-assistant`,
+      role: "assistant",
+      text: buildAssistantReply({
+        prompt: trimmed,
+        memory,
+        events,
+        conversionInputs
+      })
+    };
+
+    setMessages((current) => [...current, userMessage, assistantMessage].slice(-18));
+    setDraft("");
+    const newEvent = appendAssistantEvent(activeProfile.id, {
+      type: "assistant_chat",
+      title: "Assistant conversation happened",
+      detail: trimmed
+    });
+    setEvents((current) => [newEvent, ...current].slice(0, 18));
+  }
+
+  return (
+    <main className="page">
+      <section className="hero panel">
+        <div>
+          <p className="eyebrow">Assistant Room</p>
+          <h1>Talk to the manager-style AI that is starting to learn your business.</h1>
+          <p className="lede">
+            This is the first real conversation room. It uses your saved assistant memory,
+            recent app events, and your last conversion snapshot to talk more like an
+            actual manager instead of a generic helper.
+          </p>
+        </div>
+        <div className="hero__note">
+          <span className="hero__badge">{memory.assistantName}</span>
+          <p>
+            Current mode: {memory.tone} · {memory.focus} focus
+          </p>
+          <p className="hero__save-state">{events.length} recent events remembered</p>
+        </div>
+      </section>
+
+      <section className="brainstorm-grid">
+        <article className="panel assistant-room">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Conversation</p>
+              <h2>Manager desk</h2>
+            </div>
+            <span className="suggestions-card__tag">Local memory for now</span>
+          </div>
+
+          <div className="chat-thread">
+            {messages.map((message) => (
+              <article
+                className={`chat-message chat-message--${message.role}`}
+                key={message.id}
+              >
+                <p className="chat-message__role">
+                  {message.role === "assistant" ? memory.assistantName : activeProfile.name}
+                </p>
+                <p className="chat-message__text">{message.text}</p>
+              </article>
+            ))}
+          </div>
+
+          <div className="chat-composer">
+            <textarea
+              className="input-card__field input-card__field--short-textarea"
+              placeholder="Ask what to focus on, what looks weak, what room to open next, or how the team should work."
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+            />
+            <div className="brainstorm-actions">
+              <button className="hero__cta" type="button" onClick={sendMessage}>
+                Ask assistant
+              </button>
+              <p className="brainstorm-actions__hint">
+                This is still a rule-based manager layer, but it now has memory and conversation history.
+              </p>
+            </div>
+          </div>
+        </article>
+
+        <article className="panel assistant-room">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Recent Memory</p>
+              <h2>What the assistant is tracking.</h2>
+            </div>
+            <span className="suggestions-card__tag">Per creator</span>
+          </div>
+          <div className="event-list">
+            {events.length ? (
+              events.slice(0, 8).map((event) => (
+                <article className="event-card" key={event.id}>
+                  <p className="event-card__title">{event.title}</p>
+                  <p className="event-card__detail">{event.detail}</p>
+                </article>
+              ))
+            ) : (
+              <div className="brainstorm-empty">
+                <p>No assistant events saved yet.</p>
+                <p>Start logging ideas or updating Conversion and the assistant will begin building a working memory.</p>
+              </div>
+            )}
+          </div>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/app/conversion/page.tsx
+++ b/app/conversion/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useCreator } from "@/components/creator-provider";
+import { appendAssistantEvent } from "@/lib/assistant-events";
 import {
   buildConversionSummary,
   buildConversionStorageKey,
@@ -15,6 +16,7 @@ export default function ConversionPage() {
   const { activeProfile } = useCreator();
   const [inputs, setInputs] = useState<ConversionInputs>(defaultConversionInputs);
   const [saveState, setSaveState] = useState("Using starter values");
+  const hasHydratedInputs = useRef(false);
   const summary = useMemo(() => buildConversionSummary(inputs), [inputs]);
   const storageKey = useMemo(() => buildConversionStorageKey(activeProfile.id), [activeProfile.id]);
 
@@ -59,9 +61,20 @@ export default function ConversionPage() {
   }, [activeProfile.name, storageKey]);
 
   useEffect(() => {
+    if (!hasHydratedInputs.current) {
+      hasHydratedInputs.current = true;
+      return;
+    }
+
     window.localStorage.setItem(storageKey, JSON.stringify(inputs));
     setSaveState(`Saved for ${activeProfile.name} on this device`);
-  }, [activeProfile.name, inputs, storageKey]);
+
+    appendAssistantEvent(activeProfile.id, {
+      type: "conversion_updated",
+      title: "Updated conversion snapshot",
+      detail: `${inputs.newSubscribers} new subs from ${inputs.ofPageViews} OF page views`
+    });
+  }, [activeProfile.id, activeProfile.name, inputs, storageKey]);
 
   return (
     <main className="page">
@@ -132,6 +145,11 @@ export default function ConversionPage() {
                 setInputs(defaultConversionInputs);
                 window.localStorage.removeItem(storageKey);
                 setSaveState(`Reset ${activeProfile.name} to starter values`);
+                appendAssistantEvent(activeProfile.id, {
+                  type: "conversion_reset",
+                  title: "Reset conversion values",
+                  detail: "Cleared the current OF conversion snapshot back to starter values."
+                });
               }}
             >
               Reset values

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -23,12 +23,14 @@ export default function CreatorPage() {
   const [assistantMemory, setAssistantMemory] = useState<AssistantMemory>(() =>
     buildDefaultAssistantMemory(activeProfile.name)
   );
+  const [hasLoadedAssistantMemory, setHasLoadedAssistantMemory] = useState(false);
 
   useEffect(() => {
     const saved = window.localStorage.getItem(buildAssistantMemoryStorageKey(activeProfile.id));
 
     if (!saved) {
       setAssistantMemory(buildDefaultAssistantMemory(activeProfile.name));
+      setHasLoadedAssistantMemory(true);
       return;
     }
 
@@ -38,17 +40,23 @@ export default function CreatorPage() {
         ...buildDefaultAssistantMemory(activeProfile.name),
         ...parsed
       });
+      setHasLoadedAssistantMemory(true);
     } catch {
       setAssistantMemory(buildDefaultAssistantMemory(activeProfile.name));
+      setHasLoadedAssistantMemory(true);
     }
   }, [activeProfile.id, activeProfile.name]);
 
   useEffect(() => {
+    if (!hasLoadedAssistantMemory) {
+      return;
+    }
+
     window.localStorage.setItem(
       buildAssistantMemoryStorageKey(activeProfile.id),
       JSON.stringify(assistantMemory)
     );
-  }, [activeProfile.id, assistantMemory]);
+  }, [activeProfile.id, assistantMemory, hasLoadedAssistantMemory]);
 
   function updateAssistantMemory(updates: Partial<AssistantMemory>) {
     setAssistantMemory((current) => ({ ...current, ...updates }));

--- a/app/globals.css
+++ b/app/globals.css
@@ -840,6 +840,68 @@ li + li {
   gap: 16px;
 }
 
+.assistant-room,
+.chat-thread,
+.event-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.assistant-room {
+  gap: 18px;
+}
+
+.chat-thread,
+.event-list {
+  gap: 14px;
+}
+
+.chat-message,
+.event-card {
+  padding: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.chat-message {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.chat-message--assistant {
+  background: linear-gradient(180deg, rgba(182, 255, 39, 0.08), rgba(255, 255, 255, 0.03));
+}
+
+.chat-message--user {
+  background: linear-gradient(180deg, rgba(255, 79, 163, 0.1), rgba(255, 255, 255, 0.03));
+}
+
+.chat-message__role,
+.event-card__title {
+  margin: 0 0 10px;
+  color: var(--lime-soft);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.chat-message__text,
+.event-card__detail {
+  margin: 0;
+  color: rgba(248, 255, 213, 0.84);
+  line-height: 1.65;
+}
+
+.chat-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.event-card {
+  background: rgba(255, 255, 255, 0.04);
+}
+
 .brainstorm-panel,
 .brainstorm-form,
 .brainstorm-list {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import {
   buildDefaultAssistantMemory,
   type AssistantMemory
 } from "@/lib/assistant-memory";
+import { appendAssistantEvent } from "@/lib/assistant-events";
 import { buildAssistantBrief } from "@/lib/assistant";
 import {
   brainstormCategories,
@@ -118,10 +119,24 @@ export default function HomePage() {
 
     setEntries((current) => [nextEntry, ...current].slice(0, 8));
     setDraft("");
+    appendAssistantEvent(activeProfile.id, {
+      type: "brainstorm_saved",
+      title: `Saved ${category.toLowerCase()}`,
+      detail: trimmed
+    });
   }
 
   function removeEntry(id: string) {
+    const removed = entries.find((entry) => entry.id === id);
     setEntries((current) => current.filter((entry) => entry.id !== id));
+
+    if (removed) {
+      appendAssistantEvent(activeProfile.id, {
+        type: "brainstorm_removed",
+        title: `Removed ${removed.category.toLowerCase()}`,
+        detail: removed.text
+      });
+    }
   }
 
   return (

--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -27,6 +27,7 @@ export function Topbar() {
       </Link>
       <nav className="topbar__nav" aria-label="Main navigation">
         <Link href="/good-morning">Good Morning</Link>
+        <Link href="/assistant">Assistant</Link>
         <Link href="/">Home</Link>
         <Link href="/insights">Insights</Link>
         <Link href="/tracker">Tracker</Link>

--- a/lib/assistant-chat.ts
+++ b/lib/assistant-chat.ts
@@ -1,0 +1,95 @@
+import type { AssistantMemory } from "@/lib/assistant-memory";
+import type { AssistantEvent } from "@/lib/assistant-events";
+import type { ConversionInputs } from "@/lib/conversion";
+
+export type AssistantChatMessage = {
+  id: string;
+  role: "assistant" | "user";
+  text: string;
+};
+
+type BuildAssistantReplyArgs = {
+  prompt: string;
+  memory: AssistantMemory;
+  events: AssistantEvent[];
+  conversionInputs: ConversionInputs | null;
+};
+
+function summarizeRecentEvents(events: AssistantEvent[]) {
+  if (!events.length) {
+    return "There has not been much recent activity yet, so the next best move is to log something real and give me more to work with.";
+  }
+
+  const latest = events.slice(0, 3).map((event) => event.title.toLowerCase());
+  return `Recent activity I am tracking: ${latest.join(", ")}.`;
+}
+
+export function buildAssistantOpeningMessages(
+  memory: AssistantMemory,
+  events: AssistantEvent[],
+  conversionInputs: ConversionInputs | null
+) {
+  const opener = `${memory.assistantName} here. I’m holding your ${memory.focus.toLowerCase()} focus, your current priority, and the latest app activity so this room can feel more like a real manager desk.`;
+  const status = conversionInputs
+    ? `Your last saved conversion snapshot is ${conversionInputs.newSubscribers} new subs from ${conversionInputs.ofPageViews} OF page views.`
+    : "You do not have a saved conversion snapshot loaded yet, so my business read is still light.";
+
+  return [
+    {
+      id: "assistant-opening-1",
+      role: "assistant" as const,
+      text: opener
+    },
+    {
+      id: "assistant-opening-2",
+      role: "assistant" as const,
+      text: `${summarizeRecentEvents(events)} ${status}`
+    },
+    {
+      id: "assistant-opening-3",
+      role: "assistant" as const,
+      text: "Ask me what to focus on, what looks weak, or which room you should open next."
+    }
+  ];
+}
+
+export function buildAssistantReply({
+  prompt,
+  memory,
+  events,
+  conversionInputs
+}: BuildAssistantReplyArgs) {
+  const normalized = prompt.trim().toLowerCase();
+  const latestEvent = events[0];
+
+  if (normalized.includes("focus") || normalized.includes("what should")) {
+    return `My current read is to focus on ${memory.currentPriority.toLowerCase()} That stays aligned with your bigger goal: ${memory.mainGoal.toLowerCase()}`;
+  }
+
+  if (normalized.includes("weak") || normalized.includes("wrong")) {
+    if (conversionInputs && conversionInputs.ofPageViews > 0) {
+      const conversionRate = ((conversionInputs.newSubscribers / conversionInputs.ofPageViews) * 100).toFixed(1);
+      return `The weakest pressure point I can see right now is the handoff into OF. Your rough conversion is about ${conversionRate}%, so I would inspect the reel-to-profile-to-OF bridge before assuming the problem is pure traffic volume.`;
+    }
+
+    return "What feels weakest right now is not having enough hard business data in the app. Give me updated conversion numbers and I can stop guessing so much.";
+  }
+
+  if (normalized.includes("next") || normalized.includes("room")) {
+    if (latestEvent?.type === "brainstorm_saved") {
+      return `Because your latest event was "${latestEvent.title.toLowerCase()}", I would either move that idea into Tracker if it is ready to execute, or into Conversion if it is really about revenue behavior.`;
+    }
+
+    if (conversionInputs) {
+      return "Open Conversion if you want the business-side read, or stay here and ask me to interpret the last numbers you saved.";
+    }
+
+    return "Open Home if you need to capture ideas, or Conversion if you have real OF numbers ready to log.";
+  }
+
+  if (normalized.includes("team") || normalized.includes("people")) {
+    return "The team shape that makes sense is: one manager on this page, then specialist assistants for insights, scripting, editing, and chat/revenue. The next technical step is to define those roles in code and let the main assistant route work between them.";
+  }
+
+  return `Here is my manager read: stay in ${memory.focus.toLowerCase()} mode, keep ${memory.successSignal.toLowerCase()} as the scorecard, and do not lose this note: ${memory.managerNotes.toLowerCase()}`;
+}

--- a/lib/assistant-events.ts
+++ b/lib/assistant-events.ts
@@ -1,0 +1,58 @@
+export type AssistantEventType =
+  | "brainstorm_saved"
+  | "brainstorm_removed"
+  | "conversion_updated"
+  | "conversion_reset"
+  | "assistant_memory_updated"
+  | "assistant_chat";
+
+export type AssistantEvent = {
+  id: string;
+  type: AssistantEventType;
+  title: string;
+  detail: string;
+  createdAt: string;
+};
+
+const MAX_EVENTS = 18;
+
+export function buildAssistantEventsStorageKey(creatorId: string) {
+  return `maddiehq:${creatorId}:assistant-events`;
+}
+
+export function readAssistantEvents(creatorId: string) {
+  const saved = window.localStorage.getItem(buildAssistantEventsStorageKey(creatorId));
+
+  if (!saved) {
+    return [] as AssistantEvent[];
+  }
+
+  try {
+    const parsed = JSON.parse(saved) as AssistantEvent[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeAssistantEvents(creatorId: string, events: AssistantEvent[]) {
+  window.localStorage.setItem(
+    buildAssistantEventsStorageKey(creatorId),
+    JSON.stringify(events.slice(0, MAX_EVENTS))
+  );
+}
+
+export function appendAssistantEvent(
+  creatorId: string,
+  event: Omit<AssistantEvent, "id" | "createdAt">
+) {
+  const nextEvent: AssistantEvent = {
+    ...event,
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    createdAt: new Date().toISOString()
+  };
+
+  const current = readAssistantEvents(creatorId);
+  writeAssistantEvents(creatorId, [nextEvent, ...current]);
+  return nextEvent;
+}


### PR DESCRIPTION
Closes #48\n\n## Summary\n- add a real Assistant room with a first chat-style interface\n- add a per-creator assistant event log stored locally\n- write brainstorm and conversion activity into assistant memory events\n- let the Assistant room read creator memory, recent events, and conversion context\n- add navigation for the Assistant room\n\n## Verification\n- npm run lint\n- curl -I http://localhost:3000/assistant\n- curl -I http://localhost:3000/\n- curl -I http://localhost:3000/creator