### PR TITLE
Define assistant team roles

### DIFF
--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -17,6 +17,7 @@ import {
   buildDefaultAssistantMemory,
   type AssistantMemory
 } from "@/lib/assistant-memory";
+import { buildAssistantTeam } from "@/lib/assistant-team";
 import {
   buildConversionStorageKey,
   defaultConversionInputs,
@@ -40,6 +41,7 @@ export default function AssistantPage() {
   const [draft, setDraft] = useState("");
 
   const chatStorageKey = useMemo(() => buildChatStorageKey(activeProfile.id), [activeProfile.id]);
+  const team = useMemo(() => buildAssistantTeam(memory), [memory]);
 
   useEffect(() => {
     setMessages([]);
@@ -116,7 +118,8 @@ export default function AssistantPage() {
     const userMessage: AssistantChatMessage = {
       id: `${Date.now()}-user`,
       role: "user",
-      text: trimmed
+      text: trimmed,
+      speaker: activeProfile.name
     };
 
     const assistantMessage: AssistantChatMessage = {
@@ -127,7 +130,8 @@ export default function AssistantPage() {
         memory,
         events,
         conversionInputs
-      })
+      }),
+      speaker: memory.assistantName
     };
 
     setMessages((current) => [...current, userMessage, assistantMessage].slice(-18));
@@ -178,7 +182,8 @@ export default function AssistantPage() {
                 key={message.id}
               >
                 <p className="chat-message__role">
-                  {message.role === "assistant" ? memory.assistantName : activeProfile.name}
+                  {message.speaker ??
+                    (message.role === "assistant" ? memory.assistantName : activeProfile.name)}
                 </p>
                 <p className="chat-message__text">{message.text}</p>
               </article>
@@ -203,6 +208,33 @@ export default function AssistantPage() {
           </div>
         </article>
 
+        <article className="panel assistant-room">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Team</p>
+              <h2>The first agency roles behind the manager.</h2>
+            </div>
+            <span className="suggestions-card__tag">{team.length} roles</span>
+          </div>
+          <div className="event-list">
+            {team.map((member) => (
+              <article className="event-card" key={member.role}>
+                <p className="event-card__title">
+                  {member.name} · {member.title}
+                </p>
+                <p className="event-card__detail">{member.specialty}</p>
+                <ul className="event-card__list">
+                  {member.responsibilities.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </article>
+      </section>
+
+      <section className="bottom-grid">
         <article className="panel assistant-room">
           <div className="suggestions-card__header">
             <div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -892,6 +892,12 @@ li + li {
   line-height: 1.65;
 }
 
+.event-card__list {
+  margin: 14px 0 0;
+  color: rgba(248, 255, 213, 0.76);
+  line-height: 1.55;
+}
+
 .chat-composer {
   display: flex;
   flex-direction: column;

--- a/lib/assistant-chat.ts
+++ b/lib/assistant-chat.ts
@@ -1,11 +1,13 @@
 import type { AssistantMemory } from "@/lib/assistant-memory";
 import type { AssistantEvent } from "@/lib/assistant-events";
 import type { ConversionInputs } from "@/lib/conversion";
+import { buildAssistantTeam, pickAssistantRoute } from "@/lib/assistant-team";
 
 export type AssistantChatMessage = {
   id: string;
   role: "assistant" | "user";
   text: string;
+  speaker?: string;
 };
 
 type BuildAssistantReplyArgs = {
@@ -29,6 +31,7 @@ export function buildAssistantOpeningMessages(
   events: AssistantEvent[],
   conversionInputs: ConversionInputs | null
 ) {
+  const team = buildAssistantTeam(memory);
   const opener = `${memory.assistantName} here. I’m holding your ${memory.focus.toLowerCase()} focus, your current priority, and the latest app activity so this room can feel more like a real manager desk.`;
   const status = conversionInputs
     ? `Your last saved conversion snapshot is ${conversionInputs.newSubscribers} new subs from ${conversionInputs.ofPageViews} OF page views.`
@@ -38,17 +41,23 @@ export function buildAssistantOpeningMessages(
     {
       id: "assistant-opening-1",
       role: "assistant" as const,
-      text: opener
+      text: opener,
+      speaker: memory.assistantName
     },
     {
       id: "assistant-opening-2",
       role: "assistant" as const,
-      text: `${summarizeRecentEvents(events)} ${status}`
+      text: `${summarizeRecentEvents(events)} ${status}`,
+      speaker: memory.assistantName
     },
     {
       id: "assistant-opening-3",
       role: "assistant" as const,
-      text: "Ask me what to focus on, what looks weak, or which room you should open next."
+      text: `The first team behind me is live now: ${team
+        .slice(1)
+        .map((member) => member.title)
+        .join(", ")}. Ask me what to focus on, what looks weak, or which specialist should take something.`,
+      speaker: memory.assistantName
     }
   ];
 }
@@ -61,35 +70,62 @@ export function buildAssistantReply({
 }: BuildAssistantReplyArgs) {
   const normalized = prompt.trim().toLowerCase();
   const latestEvent = events[0];
+  const team = buildAssistantTeam(memory);
+  const route = pickAssistantRoute(normalized);
+  const routedMember = team.find((member) => member.role === route) ?? team[0];
+
+  const withDelegation = (text: string) => {
+    if (route === "manager") {
+      return text;
+    }
+
+    return `${text} I’d hand this to ${routedMember.name}, the ${routedMember.title.toLowerCase()}, for the deeper pass.`;
+  };
 
   if (normalized.includes("focus") || normalized.includes("what should")) {
-    return `My current read is to focus on ${memory.currentPriority.toLowerCase()} That stays aligned with your bigger goal: ${memory.mainGoal.toLowerCase()}`;
+    return withDelegation(
+      `My current read is to focus on ${memory.currentPriority.toLowerCase()} That stays aligned with your bigger goal: ${memory.mainGoal.toLowerCase()}`
+    );
   }
 
   if (normalized.includes("weak") || normalized.includes("wrong")) {
     if (conversionInputs && conversionInputs.ofPageViews > 0) {
       const conversionRate = ((conversionInputs.newSubscribers / conversionInputs.ofPageViews) * 100).toFixed(1);
-      return `The weakest pressure point I can see right now is the handoff into OF. Your rough conversion is about ${conversionRate}%, so I would inspect the reel-to-profile-to-OF bridge before assuming the problem is pure traffic volume.`;
+      return withDelegation(
+        `The weakest pressure point I can see right now is the handoff into OF. Your rough conversion is about ${conversionRate}%, so I would inspect the reel-to-profile-to-OF bridge before assuming the problem is pure traffic volume.`
+      );
     }
 
-    return "What feels weakest right now is not having enough hard business data in the app. Give me updated conversion numbers and I can stop guessing so much.";
+    return withDelegation(
+      "What feels weakest right now is not having enough hard business data in the app. Give me updated conversion numbers and I can stop guessing so much."
+    );
   }
 
   if (normalized.includes("next") || normalized.includes("room")) {
     if (latestEvent?.type === "brainstorm_saved") {
-      return `Because your latest event was "${latestEvent.title.toLowerCase()}", I would either move that idea into Tracker if it is ready to execute, or into Conversion if it is really about revenue behavior.`;
+      return withDelegation(
+        `Because your latest event was "${latestEvent.title.toLowerCase()}", I would either move that idea into Tracker if it is ready to execute, or into Conversion if it is really about revenue behavior.`
+      );
     }
 
     if (conversionInputs) {
-      return "Open Conversion if you want the business-side read, or stay here and ask me to interpret the last numbers you saved.";
+      return withDelegation(
+        "Open Conversion if you want the business-side read, or stay here and ask me to interpret the last numbers you saved."
+      );
     }
 
-    return "Open Home if you need to capture ideas, or Conversion if you have real OF numbers ready to log.";
+    return withDelegation(
+      "Open Home if you need to capture ideas, or Conversion if you have real OF numbers ready to log."
+    );
   }
 
   if (normalized.includes("team") || normalized.includes("people")) {
-    return "The team shape that makes sense is: one manager on this page, then specialist assistants for insights, scripting, editing, and chat/revenue. The next technical step is to define those roles in code and let the main assistant route work between them.";
+    return `The team shape now is: ${team
+      .map((member) => `${member.name} for ${member.title.toLowerCase()}`)
+      .join(", ")}. My job is to manage the whole picture and route the specialist work where it belongs.`;
   }
 
-  return `Here is my manager read: stay in ${memory.focus.toLowerCase()} mode, keep ${memory.successSignal.toLowerCase()} as the scorecard, and do not lose this note: ${memory.managerNotes.toLowerCase()}`;
+  return withDelegation(
+    `Here is my manager read: stay in ${memory.focus.toLowerCase()} mode, keep ${memory.successSignal.toLowerCase()} as the scorecard, and do not lose this note: ${memory.managerNotes.toLowerCase()}`
+  );
 }

--- a/lib/assistant-team.ts
+++ b/lib/assistant-team.ts
@@ -1,0 +1,124 @@
+import type { AssistantMemory } from "@/lib/assistant-memory";
+
+export type AssistantRole =
+  | "manager"
+  | "insights"
+  | "scripting"
+  | "editing"
+  | "chat-revenue";
+
+export type AssistantTeamMember = {
+  role: AssistantRole;
+  name: string;
+  title: string;
+  specialty: string;
+  responsibilities: string[];
+};
+
+export function buildAssistantTeam(memory: AssistantMemory): AssistantTeamMember[] {
+  return [
+    {
+      role: "manager",
+      name: memory.assistantName,
+      title: "Agency Manager",
+      specialty: "Keeps the full business picture in view and routes work to the right specialist.",
+      responsibilities: [
+        "Sets priority and next moves",
+        "Connects insights, execution, and revenue",
+        "Acts like the front-facing manager"
+      ]
+    },
+    {
+      role: "insights",
+      name: "Signal",
+      title: "Insights Analyst",
+      specialty: "Reads content performance, patterns, and growth signals.",
+      responsibilities: [
+        "Spot what is working and what is weak",
+        "Compare reels and traffic quality",
+        "Turn metrics into simple explanations"
+      ]
+    },
+    {
+      role: "scripting",
+      name: "Muse",
+      title: "Script Strategist",
+      specialty: "Shapes hooks, captions, CTAs, and message framing.",
+      responsibilities: [
+        "Refine reel hooks and caption tone",
+        "Turn ideas into stronger scripts",
+        "Help with promo wording and CTA direction"
+      ]
+    },
+    {
+      role: "editing",
+      name: "Cut",
+      title: "Editing Lead",
+      specialty: "Guides pacing, structure, and post-production decisions.",
+      responsibilities: [
+        "Improve pacing and first-three-second impact",
+        "Suggest cutdowns and overlay direction",
+        "Tighten content for clarity"
+      ]
+    },
+    {
+      role: "chat-revenue",
+      name: "Closer",
+      title: "Chat and Revenue Lead",
+      specialty: "Focuses on conversion, spending behavior, and revenue-side strategy.",
+      responsibilities: [
+        "Think about buyer intent and spending patterns",
+        "Connect OF behavior to content traffic",
+        "Later guide chat-team style workflows"
+      ]
+    }
+  ];
+}
+
+export function pickAssistantRoute(prompt: string): AssistantRole {
+  const normalized = prompt.toLowerCase();
+
+  if (
+    normalized.includes("view") ||
+    normalized.includes("insight") ||
+    normalized.includes("performance") ||
+    normalized.includes("analytics") ||
+    normalized.includes("weak") ||
+    normalized.includes("working")
+  ) {
+    return "insights";
+  }
+
+  if (
+    normalized.includes("script") ||
+    normalized.includes("caption") ||
+    normalized.includes("hook") ||
+    normalized.includes("write") ||
+    normalized.includes("cta")
+  ) {
+    return "scripting";
+  }
+
+  if (
+    normalized.includes("edit") ||
+    normalized.includes("video") ||
+    normalized.includes("cut") ||
+    normalized.includes("trim") ||
+    normalized.includes("cover")
+  ) {
+    return "editing";
+  }
+
+  if (
+    normalized.includes("revenue") ||
+    normalized.includes("sub") ||
+    normalized.includes("onlyfans") ||
+    normalized.includes("chat") ||
+    normalized.includes("spend") ||
+    normalized.includes("conversion")
+  ) {
+    return "chat-revenue";
+  }
+
+  return "manager";
+}


### PR DESCRIPTION
Closes #50\n\n## Summary\n- add a shared assistant team model with named specialist roles\n- show the first agency-style team inside the Assistant room\n- teach the manager assistant to route questions toward the right specialist role\n- make assistant replies talk in terms of delegation instead of one generic helper voice\n\n## Verification\n- npm run lint\n- curl -I http://localhost:3000/assistant\n- curl -I http://localhost:3000/