### PR TITLE
Rename manager bot and add quick launcher answer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -104,7 +104,7 @@ body {
 .floating-assistant__actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 14px;
   margin-top: 16px;
 }
@@ -160,6 +160,52 @@ body {
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
+}
+
+.floating-assistant__quick {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.floating-assistant__input {
+  min-height: 86px;
+  resize: vertical;
+}
+
+.floating-assistant__quick-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.floating-assistant__answer {
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.floating-assistant__answer-label,
+.floating-assistant__answer-text {
+  margin: 0;
+}
+
+.floating-assistant__answer-label {
+  color: var(--lime-soft);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.floating-assistant__answer-text {
+  margin-top: 10px;
+  color: rgba(248, 255, 213, 0.84);
+  line-height: 1.6;
 }
 
 .topbar {

--- a/components/floating-assistant.tsx
+++ b/components/floating-assistant.tsx
@@ -4,12 +4,18 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useCreator } from "@/components/creator-provider";
+import { buildAssistantReply } from "@/lib/assistant-chat";
+import { appendAssistantEvent, readAssistantEvents, type AssistantEvent } from "@/lib/assistant-events";
 import {
   buildAssistantMemoryStorageKey,
   hydrateAssistantMemory,
   type AssistantMemory
 } from "@/lib/assistant-memory";
-import { readAssistantEvents } from "@/lib/assistant-events";
+import {
+  buildConversionStorageKey,
+  defaultConversionInputs,
+  type ConversionInputs
+} from "@/lib/conversion";
 
 export function FloatingAssistant() {
   const pathname = usePathname();
@@ -19,6 +25,10 @@ export function FloatingAssistant() {
     hydrateAssistantMemory(activeProfile.name)
   );
   const [recentEventTitle, setRecentEventTitle] = useState("");
+  const [events, setEvents] = useState<AssistantEvent[]>([]);
+  const [conversionInputs, setConversionInputs] = useState<ConversionInputs | null>(null);
+  const [quickQuestion, setQuickQuestion] = useState("");
+  const [quickAnswer, setQuickAnswer] = useState("");
 
   useEffect(() => {
     const saved = window.localStorage.getItem(buildAssistantMemoryStorageKey(activeProfile.id));
@@ -33,9 +43,52 @@ export function FloatingAssistant() {
       setMemory(hydrateAssistantMemory(activeProfile.name));
     }
 
-    const latestEvent = readAssistantEvents(activeProfile.id)[0];
+    const savedEvents = readAssistantEvents(activeProfile.id);
+    const latestEvent = savedEvents[0];
+    setEvents(savedEvents);
     setRecentEventTitle(latestEvent?.title ?? "");
+
+    const savedConversion = window.localStorage.getItem(buildConversionStorageKey(activeProfile.id));
+    if (savedConversion) {
+      try {
+        setConversionInputs({
+          ...defaultConversionInputs,
+          ...(JSON.parse(savedConversion) as Partial<ConversionInputs>)
+        });
+      } catch {
+        setConversionInputs(null);
+      }
+    } else {
+      setConversionInputs(null);
+    }
+
+    setQuickQuestion("");
+    setQuickAnswer("");
   }, [activeProfile.id, activeProfile.name, pathname]);
+
+  function askQuickQuestion() {
+    const trimmed = quickQuestion.trim();
+
+    if (!trimmed) {
+      return;
+    }
+
+    const answer = buildAssistantReply({
+      prompt: trimmed,
+      memory,
+      events,
+      conversionInputs
+    });
+
+    setQuickAnswer(answer);
+    const newEvent = appendAssistantEvent(activeProfile.id, {
+      type: "assistant_chat",
+      title: "Quick manager question",
+      detail: trimmed
+    });
+    setEvents((current) => [newEvent, ...current].slice(0, 18));
+    setRecentEventTitle(newEvent.title);
+  }
 
   return (
     <div className="floating-assistant">
@@ -47,7 +100,7 @@ export function FloatingAssistant() {
               <h2>{memory.assistantName}</h2>
             </div>
             <button
-              aria-label="Close Kian launcher"
+              aria-label="Close manager bot launcher"
               className="floating-assistant__close"
               type="button"
               onClick={() => setOpen(false)}
@@ -63,26 +116,47 @@ export function FloatingAssistant() {
               : "I am ready when you want a quick manager read or want to jump into the full assistant room."}
           </p>
 
+          <div className="floating-assistant__quick">
+            <textarea
+              className="input-card__field floating-assistant__input"
+              placeholder="Ask one quick question..."
+              value={quickQuestion}
+              onChange={(event) => setQuickQuestion(event.target.value)}
+            />
+            <div className="floating-assistant__quick-actions">
+              <button className="hero__cta" type="button" onClick={askQuickQuestion}>
+                Ask
+              </button>
+              <span className="floating-assistant__status">
+                {memory.tone} · {memory.focus} focus
+              </span>
+            </div>
+          </div>
+
+          {quickAnswer ? (
+            <div className="floating-assistant__answer">
+              <p className="floating-assistant__answer-label">{memory.assistantName}</p>
+              <p className="floating-assistant__answer-text">{quickAnswer}</p>
+            </div>
+          ) : null}
+
           <div className="floating-assistant__actions">
             <Link className="hero__cta" href="/assistant" onClick={() => setOpen(false)}>
-              Open Kian
+              Open Assistant Room
             </Link>
-            <span className="floating-assistant__status">
-              {memory.tone} · {memory.focus} focus
-            </span>
           </div>
         </div>
       ) : null}
 
       <button
-        aria-label="Open Kian assistant"
+        aria-label="Open manager bot assistant"
         className="floating-assistant__bubble"
         type="button"
         onClick={() => setOpen((current) => !current)}
       >
         <span className="floating-assistant__glow" aria-hidden="true" />
-        <span className="floating-assistant__name">Kian</span>
-        <span className="floating-assistant__hint">Manager</span>
+        <span className="floating-assistant__name">Manager Bot</span>
+        <span className="floating-assistant__hint">Quick Help</span>
       </button>
     </div>
   );

--- a/lib/assistant-memory.ts
+++ b/lib/assistant-memory.ts
@@ -27,7 +27,7 @@ export type AssistantMemory = {
 };
 
 function isLegacyAssistantName(name: string, profileName: string) {
-  return !name.trim() || name === `${profileName}'s assistant`;
+  return !name.trim() || name === `${profileName}'s assistant` || name === "Kian";
 }
 
 export function buildAssistantMemoryStorageKey(creatorId: string) {
@@ -36,7 +36,7 @@ export function buildAssistantMemoryStorageKey(creatorId: string) {
 
 export function buildDefaultAssistantMemory(profileName: string): AssistantMemory {
   return {
-    assistantName: "Kian",
+    assistantName: "Manager Bot",
     tone: "Warm manager",
     focus: "Balanced",
     mainGoal: "Turn Instagram traffic into stronger OF conversion and steadier revenue.",


### PR DESCRIPTION
Closes #54\n\n## Summary\n- rename the default floating manager identity from Kian to Manager Bot\n- migrate old default names cleanly through assistant-memory hydration\n- add a quick one-question answer flow inside the floating launcher\n- keep the full Assistant room for deeper conversations\n\n## Verification\n- npm run lint\n- curl -I http://localhost:3000/\n- curl -I http://localhost:3000/assistant