### PR TITLE
Surface conversion context in manager bot

### DIFF
--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/assistant-memory";
 import { buildAssistantTeam } from "@/lib/assistant-team";
 import {
+  buildConversionSnapshot,
   buildConversionStorageKey,
   defaultConversionInputs,
   type ConversionInputs
@@ -42,6 +43,10 @@ export default function AssistantPage() {
 
   const chatStorageKey = useMemo(() => buildChatStorageKey(activeProfile.id), [activeProfile.id]);
   const team = useMemo(() => buildAssistantTeam(memory), [memory]);
+  const conversionSnapshot = useMemo(
+    () => (conversionInputs ? buildConversionSnapshot(conversionInputs) : null),
+    [conversionInputs]
+  );
 
   useEffect(() => {
     setMessages([]);
@@ -163,6 +168,12 @@ export default function AssistantPage() {
           <p>
             Current mode: {memory.tone} · {memory.focus} focus
           </p>
+          {conversionSnapshot ? (
+            <p className="hero__save-state">
+              Leading with {conversionSnapshot.ofConversionLabel} OF conversion from{" "}
+              {conversionSnapshot.pageViewsLabel} OF page views.
+            </p>
+          ) : null}
           <p className="hero__save-state">{events.length} recent events remembered</p>
         </div>
       </section>
@@ -237,6 +248,41 @@ export default function AssistantPage() {
       </section>
 
       <section className="bottom-grid">
+        <article className="panel assistant-room">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Manager Conversion Read</p>
+              <h2>What the manager is holding in mind right now.</h2>
+            </div>
+            <span className="suggestions-card__tag">Business context</span>
+          </div>
+          {conversionSnapshot ? (
+            <div className="metric-grid">
+              <article className="metric">
+                <p className="metric__label">OF Conversion</p>
+                <p className="metric__value">{conversionSnapshot.ofConversionLabel}</p>
+              </article>
+              <article className="metric">
+                <p className="metric__label">Profile To OF</p>
+                <p className="metric__value">{conversionSnapshot.profileToOfLabel}</p>
+              </article>
+              <article className="metric">
+                <p className="metric__label">New Subs</p>
+                <p className="metric__value">{conversionSnapshot.subsLabel}</p>
+              </article>
+              <article className="metric">
+                <p className="metric__label">Top Spender</p>
+                <p className="metric__value">{conversionSnapshot.topSpenderLabel}</p>
+              </article>
+            </div>
+          ) : (
+            <div className="brainstorm-empty">
+              <p>No conversion snapshot loaded yet.</p>
+              <p>Update the Conversion room and the manager will start carrying those numbers here.</p>
+            </div>
+          )}
+        </article>
+
         <article className="panel assistant-room">
           <div className="suggestions-card__header">
             <div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -169,6 +169,47 @@ body {
   margin-top: 16px;
 }
 
+.floating-assistant__conversion {
+  margin-top: 16px;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(182, 255, 39, 0.08);
+  border: 1px solid rgba(182, 255, 39, 0.14);
+}
+
+.floating-assistant__conversion-label {
+  margin: 0 0 12px;
+  color: var(--lime-soft);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.floating-assistant__conversion-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.floating-assistant__conversion-grid span,
+.floating-assistant__conversion-grid strong {
+  display: block;
+}
+
+.floating-assistant__conversion-grid span {
+  color: rgba(248, 255, 213, 0.62);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.floating-assistant__conversion-grid strong {
+  margin-top: 4px;
+  color: var(--text);
+  font-size: 1rem;
+}
+
 .floating-assistant__input {
   min-height: 86px;
   resize: vertical;

--- a/components/floating-assistant.tsx
+++ b/components/floating-assistant.tsx
@@ -12,6 +12,7 @@ import {
   type AssistantMemory
 } from "@/lib/assistant-memory";
 import {
+  buildConversionSnapshot,
   buildConversionStorageKey,
   defaultConversionInputs,
   type ConversionInputs
@@ -29,6 +30,7 @@ export function FloatingAssistant() {
   const [conversionInputs, setConversionInputs] = useState<ConversionInputs | null>(null);
   const [quickQuestion, setQuickQuestion] = useState("");
   const [quickAnswer, setQuickAnswer] = useState("");
+  const conversionSnapshot = conversionInputs ? buildConversionSnapshot(conversionInputs) : null;
 
   useEffect(() => {
     const saved = window.localStorage.getItem(buildAssistantMemoryStorageKey(activeProfile.id));
@@ -116,10 +118,34 @@ export function FloatingAssistant() {
               : "I am ready when you want a quick manager read or want to jump into the full assistant room."}
           </p>
 
+          {conversionSnapshot ? (
+            <div className="floating-assistant__conversion">
+              <p className="floating-assistant__conversion-label">Conversion read</p>
+              <div className="floating-assistant__conversion-grid">
+                <div>
+                  <span>OF conversion</span>
+                  <strong>{conversionSnapshot.ofConversionLabel}</strong>
+                </div>
+                <div>
+                  <span>New subs</span>
+                  <strong>{conversionSnapshot.subsLabel}</strong>
+                </div>
+                <div>
+                  <span>OF page views</span>
+                  <strong>{conversionSnapshot.pageViewsLabel}</strong>
+                </div>
+                <div>
+                  <span>Top spender</span>
+                  <strong>{conversionSnapshot.topSpenderLabel}</strong>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
           <div className="floating-assistant__quick">
             <textarea
               className="input-card__field floating-assistant__input"
-              placeholder="Ask one quick question..."
+              placeholder="Ask one quick question, like how conversions look..."
               value={quickQuestion}
               onChange={(event) => setQuickQuestion(event.target.value)}
             />

--- a/lib/assistant-chat.ts
+++ b/lib/assistant-chat.ts
@@ -1,6 +1,6 @@
 import type { AssistantMemory } from "@/lib/assistant-memory";
 import type { AssistantEvent } from "@/lib/assistant-events";
-import type { ConversionInputs } from "@/lib/conversion";
+import { buildConversionSnapshot, type ConversionInputs } from "@/lib/conversion";
 import {
   buildAssistantTeam,
   pickAssistantRoute,
@@ -64,11 +64,14 @@ function buildSpecialistReply(args: {
           : "If a post feels weak, I would inspect the opening, the trim, and whether the visual matches the hook."
       }`;
     case "chat-revenue":
-      return `Closer's read: I care about buyer intent more than surface attention. ${
-        conversionInputs
-          ? `With ${conversionInputs.ofPageViews} OF page views and ${conversionInputs.newSubscribers} new subs saved, I would inspect where curiosity is failing to become paid behavior.`
-          : "Without updated conversion numbers, I would treat any revenue conclusion as a loose guess."
-      }`;
+      if (!conversionInputs) {
+        return "Closer's read: without updated conversion numbers, I would treat any revenue conclusion as a loose guess.";
+      }
+
+      {
+        const snapshot = buildConversionSnapshot(conversionInputs);
+        return `Closer's read: I care about buyer intent more than surface attention. Right now you are sitting at ${snapshot.ofConversionLabel} OF conversion from ${snapshot.pageViewsLabel} OF page views, with a top spender at ${snapshot.topSpenderLabel}. I would inspect where curiosity is failing to become paid behavior.`;
+      }
     default:
       return `Manager read: stay aligned with ${memory.mainGoal.toLowerCase()} and keep ${memory.currentPriority.toLowerCase()} at the top of the stack.`;
   }
@@ -154,9 +157,9 @@ export function buildAssistantReply({
 
   if (normalized.includes("weak") || normalized.includes("wrong")) {
     if (conversionInputs && conversionInputs.ofPageViews > 0) {
-      const conversionRate = ((conversionInputs.newSubscribers / conversionInputs.ofPageViews) * 100).toFixed(1);
+      const snapshot = buildConversionSnapshot(conversionInputs);
       return combineWithSpecialist(
-        `The weakest pressure point I can see right now is the handoff into OF. Your rough conversion is about ${conversionRate}%, so I would inspect the reel-to-profile-to-OF bridge before assuming the problem is pure traffic volume.`
+        `The weakest pressure point I can see right now is the handoff into OF. Your rough conversion is about ${snapshot.ofConversionLabel}, so I would inspect the reel-to-profile-to-OF bridge before assuming the problem is pure traffic volume.`
       );
     }
 
@@ -180,6 +183,24 @@ export function buildAssistantReply({
 
     return combineWithSpecialist(
       "Open Home if you need to capture ideas, or Conversion if you have real OF numbers ready to log."
+    );
+  }
+
+  if (
+    normalized.includes("conversion") ||
+    normalized.includes("subscribers") ||
+    normalized.includes("subs") ||
+    normalized.includes("page views")
+  ) {
+    if (conversionInputs) {
+      const snapshot = buildConversionSnapshot(conversionInputs);
+      return combineWithSpecialist(
+        `Manager Bot read: the current conversion picture is ${snapshot.ofConversionLabel} OF conversion from ${snapshot.pageViewsLabel} OF page views, with ${snapshot.subsLabel} new subs and ${snapshot.topSpenderLabel} as the top spender signal.`
+      );
+    }
+
+    return combineWithSpecialist(
+      "Manager Bot read: I do not have a saved conversion snapshot yet, so the next move is to update the Conversion room and give me real numbers to work from."
     );
   }
 

--- a/lib/conversion.ts
+++ b/lib/conversion.ts
@@ -125,6 +125,23 @@ export function buildConversionSummary(inputs: ConversionInputs) {
   };
 }
 
+export function buildConversionSnapshot(inputs: ConversionInputs) {
+  const ofConversionRate =
+    inputs.ofPageViews > 0 ? (inputs.newSubscribers / inputs.ofPageViews) * 100 : 0;
+  const profileToOfRate =
+    inputs.profileVisits > 0 ? (inputs.ofPageViews / inputs.profileVisits) * 100 : 0;
+
+  return {
+    ofConversionRate,
+    profileToOfRate,
+    ofConversionLabel: formatPercent(ofConversionRate),
+    profileToOfLabel: formatPercent(profileToOfRate),
+    subsLabel: formatWholeNumber(inputs.newSubscribers),
+    pageViewsLabel: formatWholeNumber(inputs.ofPageViews),
+    topSpenderLabel: formatCurrency(inputs.topSpenderAmount)
+  };
+}
+
 export const managerNotes = [
   "Track OF page views and new subscribers together so the app can calculate your rough conversion rate automatically.",
   "When a reel brings subs, note the hook, cover, and posting window so you can compare what kind of traffic converts best.",


### PR DESCRIPTION
Closes #60\n\n## Summary\n- add a conversion snapshot to the floating Manager Bot launcher\n- add a manager conversion read section inside the Assistant room\n- improve manager replies for conversion-style questions\n- keep the standalone Conversion room as the detailed data-entry surface\n\n## Verification\n- npm run lint\n- curl -I http://localhost:3000/\n- curl -I http://localhost:3000/assistant