### PR TITLE
Simplify floating bot and move quick actions

### DIFF
--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -47,6 +47,12 @@ export default function AssistantPage() {
     () => (conversionInputs ? buildConversionSnapshot(conversionInputs) : null),
     [conversionInputs]
   );
+  const quickPrompts = [
+    "How are conversions looking right now?",
+    "What should I focus on next?",
+    "What looks weak in my content system?",
+    "Which specialist should take this?"
+  ];
 
   useEffect(() => {
     setMessages([]);
@@ -151,6 +157,35 @@ export default function AssistantPage() {
     setEvents((current) => [newEvent, ...current].slice(0, 18));
   }
 
+  function runQuickPrompt(prompt: string) {
+    const userMessage: AssistantChatMessage = {
+      id: `${Date.now()}-quick-user`,
+      role: "user",
+      text: prompt,
+      speaker: activeProfile.name
+    };
+
+    const assistantMessage: AssistantChatMessage = {
+      id: `${Date.now()}-quick-assistant`,
+      role: "assistant",
+      text: buildAssistantReply({
+        prompt,
+        memory,
+        events,
+        conversionInputs
+      }),
+      speaker: memory.assistantName
+    };
+
+    setMessages((current) => [...current, userMessage, assistantMessage].slice(-18));
+    const newEvent = appendAssistantEvent(activeProfile.id, {
+      type: "assistant_chat",
+      title: "Assistant quick action used",
+      detail: prompt
+    });
+    setEvents((current) => [newEvent, ...current].slice(0, 18));
+  }
+
   return (
     <main className="page">
       <section className="hero panel">
@@ -204,6 +239,18 @@ export default function AssistantPage() {
           </div>
 
           <div className="chat-composer">
+            <div className="assistant-room__quick-actions">
+              {quickPrompts.map((prompt) => (
+                <button
+                  className="assistant-room__quick-button"
+                  key={prompt}
+                  type="button"
+                  onClick={() => runQuickPrompt(prompt)}
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
             <textarea
               className="input-card__field input-card__field--short-textarea"
               placeholder="Ask what to focus on, what looks weak, what room to open next, or how the team should work."

--- a/app/globals.css
+++ b/app/globals.css
@@ -210,6 +210,22 @@ body {
   font-size: 1rem;
 }
 
+.assistant-room__quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.assistant-room__quick-button {
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 79, 163, 0.08);
+  color: var(--text);
+  font: inherit;
+  font-weight: 700;
+}
+
 .floating-assistant__input {
   min-height: 86px;
   resize: vertical;

--- a/components/floating-assistant.tsx
+++ b/components/floating-assistant.tsx
@@ -4,8 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useCreator } from "@/components/creator-provider";
-import { buildAssistantReply } from "@/lib/assistant-chat";
-import { appendAssistantEvent, readAssistantEvents, type AssistantEvent } from "@/lib/assistant-events";
+import { readAssistantEvents } from "@/lib/assistant-events";
 import {
   buildAssistantMemoryStorageKey,
   hydrateAssistantMemory,
@@ -26,10 +25,7 @@ export function FloatingAssistant() {
     hydrateAssistantMemory(activeProfile.name)
   );
   const [recentEventTitle, setRecentEventTitle] = useState("");
-  const [events, setEvents] = useState<AssistantEvent[]>([]);
   const [conversionInputs, setConversionInputs] = useState<ConversionInputs | null>(null);
-  const [quickQuestion, setQuickQuestion] = useState("");
-  const [quickAnswer, setQuickAnswer] = useState("");
   const conversionSnapshot = conversionInputs ? buildConversionSnapshot(conversionInputs) : null;
 
   useEffect(() => {
@@ -47,7 +43,6 @@ export function FloatingAssistant() {
 
     const savedEvents = readAssistantEvents(activeProfile.id);
     const latestEvent = savedEvents[0];
-    setEvents(savedEvents);
     setRecentEventTitle(latestEvent?.title ?? "");
 
     const savedConversion = window.localStorage.getItem(buildConversionStorageKey(activeProfile.id));
@@ -63,34 +58,7 @@ export function FloatingAssistant() {
     } else {
       setConversionInputs(null);
     }
-
-    setQuickQuestion("");
-    setQuickAnswer("");
   }, [activeProfile.id, activeProfile.name, pathname]);
-
-  function askQuickQuestion() {
-    const trimmed = quickQuestion.trim();
-
-    if (!trimmed) {
-      return;
-    }
-
-    const answer = buildAssistantReply({
-      prompt: trimmed,
-      memory,
-      events,
-      conversionInputs
-    });
-
-    setQuickAnswer(answer);
-    const newEvent = appendAssistantEvent(activeProfile.id, {
-      type: "assistant_chat",
-      title: "Quick manager question",
-      detail: trimmed
-    });
-    setEvents((current) => [newEvent, ...current].slice(0, 18));
-    setRecentEventTitle(newEvent.title);
-  }
 
   return (
     <div className="floating-assistant">
@@ -142,31 +110,10 @@ export function FloatingAssistant() {
             </div>
           ) : null}
 
-          <div className="floating-assistant__quick">
-            <textarea
-              className="input-card__field floating-assistant__input"
-              placeholder="Ask one quick question, like how conversions look..."
-              value={quickQuestion}
-              onChange={(event) => setQuickQuestion(event.target.value)}
-            />
-            <div className="floating-assistant__quick-actions">
-              <button className="hero__cta" type="button" onClick={askQuickQuestion}>
-                Ask
-              </button>
-              <span className="floating-assistant__status">
-                {memory.tone} · {memory.focus} focus
-              </span>
-            </div>
-          </div>
-
-          {quickAnswer ? (
-            <div className="floating-assistant__answer">
-              <p className="floating-assistant__answer-label">{memory.assistantName}</p>
-              <p className="floating-assistant__answer-text">{quickAnswer}</p>
-            </div>
-          ) : null}
-
           <div className="floating-assistant__actions">
+            <span className="floating-assistant__status">
+              {memory.tone} · {memory.focus} focus
+            </span>
             <Link className="hero__cta" href="/assistant" onClick={() => setOpen(false)}>
               Open Assistant Room
             </Link>


### PR DESCRIPTION
Closes #62\n\n## Summary\n- shrink the floating Manager Bot back to a lightweight opener\n- remove the inline quick-question flow from the floating launcher\n- add quick-action buttons inside the Assistant room\n- make the Assistant room the clearer working surface for manager interactions\n\n## Verification\n- npm run lint\n- curl -I http://localhost:3000/\n- curl -I http://localhost:3000/assistant