### PR TITLE
Redesign homepage as command room

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -675,6 +675,23 @@ h1 {
   line-height: 1.6;
 }
 
+.command-hero .hero__note {
+  background: linear-gradient(180deg, rgba(182, 255, 39, 0.12), rgba(255, 79, 163, 0.08));
+}
+
+.command-brief {
+  border-color: rgba(182, 255, 39, 0.26);
+}
+
+.command-grid,
+.command-stats {
+  align-items: stretch;
+}
+
+.command-panel {
+  min-height: 100%;
+}
+
 .brainstorm-grid {
   display: grid;
   grid-template-columns: 1.05fr 0.95fr;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import {
   hydrateAssistantMemory,
   type AssistantMemory
 } from "@/lib/assistant-memory";
-import { appendAssistantEvent } from "@/lib/assistant-events";
+import { appendAssistantEvent, readAssistantEvents, type AssistantEvent } from "@/lib/assistant-events";
 import { buildAssistantBrief } from "@/lib/assistant";
 import {
   brainstormCategories,
@@ -16,10 +16,12 @@ import {
   type BrainstormEntry
 } from "@/lib/brainstorm";
 import {
+  buildConversionSnapshot,
   buildConversionStorageKey,
   defaultConversionInputs,
   type ConversionInputs
 } from "@/lib/conversion";
+import { buildTrackerStats, buildTrackerStorageKey, defaultTrackerTasks, type TrackerTask } from "@/lib/tracker";
 
 const STORAGE_KEY = "maddiehq:brainstorms";
 
@@ -32,6 +34,8 @@ export default function HomePage() {
   const [assistantMemory, setAssistantMemory] = useState<AssistantMemory>(() =>
     hydrateAssistantMemory(activeProfile.name)
   );
+  const [trackerTasks, setTrackerTasks] = useState<TrackerTask[]>(defaultTrackerTasks);
+  const [events, setEvents] = useState<AssistantEvent[]>([]);
 
   useEffect(() => {
     const saved = window.localStorage.getItem(STORAGE_KEY);
@@ -71,6 +75,22 @@ export default function HomePage() {
   }, [activeProfile.id]);
 
   useEffect(() => {
+    const saved = window.localStorage.getItem(buildTrackerStorageKey(activeProfile.id));
+
+    if (!saved) {
+      setTrackerTasks(defaultTrackerTasks);
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(saved) as TrackerTask[];
+      setTrackerTasks(Array.isArray(parsed) && parsed.length ? parsed : defaultTrackerTasks);
+    } catch {
+      setTrackerTasks(defaultTrackerTasks);
+    }
+  }, [activeProfile.id]);
+
+  useEffect(() => {
     const saved = window.localStorage.getItem(buildAssistantMemoryStorageKey(activeProfile.id));
 
     if (!saved) {
@@ -86,6 +106,10 @@ export default function HomePage() {
     }
   }, [activeProfile.id, activeProfile.name]);
 
+  useEffect(() => {
+    setEvents(readAssistantEvents(activeProfile.id));
+  }, [activeProfile.id, entries, trackerTasks, conversionInputs]);
+
   const suggestions = useMemo(() => buildBrainstormSuggestions(draft, category), [category, draft]);
   const assistantBrief = useMemo(
     () =>
@@ -99,6 +123,16 @@ export default function HomePage() {
       }),
     [activeProfile.name, assistantMemory, category, conversionInputs, draft, entries]
   );
+  const conversionSnapshot = useMemo(
+    () => (conversionInputs ? buildConversionSnapshot(conversionInputs) : null),
+    [conversionInputs]
+  );
+  const trackerStats = useMemo(() => buildTrackerStats(trackerTasks), [trackerTasks]);
+  const priorityTasks = useMemo(
+    () => trackerTasks.filter((task) => task.status !== "Posted").slice(0, 4),
+    [trackerTasks]
+  );
+  const recentEvents = useMemo(() => events.slice(0, 4), [events]);
 
   function saveEntry() {
     const trimmed = draft.trim();
@@ -138,30 +172,29 @@ export default function HomePage() {
 
   return (
     <main className="page">
-      <section className="hero panel">
+      <section className="hero panel command-hero">
         <div>
-          <p className="eyebrow">Maddie HQ</p>
-          <h1>Use the homepage like a brainstorm desk, not just a hallway.</h1>
+          <p className="eyebrow">Command Room</p>
+          <h1>See what matters now, what is moving, and what the manager wants next.</h1>
           <p className="lede">
-            Drop rough ideas here while they are still fresh, let the app suggest what
-            kind of move it could become, then jump into the room that helps you act on it.
+            Home should feel like the briefing board for the whole app. Start here for the
+            manager read, workflow urgency, business pulse, and a quick place to capture ideas.
           </p>
         </div>
         <div className="hero__note">
-          <span className="hero__badge">Brainstorm mode</span>
+          <span className="hero__badge">Manager briefing</span>
           <p>
-            This homepage now acts like a quick capture notebook with lightweight guidance.
+            Current operator: {assistantMemory.assistantName}
           </p>
+          <p className="hero__save-state">{assistantMemory.currentPriority}</p>
         </div>
       </section>
 
-      <section className="panel assistant-card">
+      <section className="panel assistant-card command-brief">
         <div className="assistant-card__copy">
           <p className="eyebrow">{assistantBrief.eyebrow}</p>
           <h2>{assistantBrief.title}</h2>
-          <p>
-            {assistantBrief.summary}
-          </p>
+          <p>{assistantBrief.summary}</p>
           <p className="assistant-card__memory-note">
             Saved mode: {assistantMemory.tone} · {assistantMemory.focus} focus
           </p>
@@ -180,12 +213,90 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="brainstorm-grid">
-        <article className="panel brainstorm-panel">
+      <section className="overview-grid command-stats">
+        {trackerStats.map((stat) => (
+          <article className="stat-card panel" key={stat.label}>
+            <p className="stat-card__label">{stat.label}</p>
+            <p className="stat-card__value">{stat.value}</p>
+            <p className="stat-card__change">{stat.detail}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="brainstorm-grid command-grid">
+        <article className="panel command-panel">
           <div className="suggestions-card__header">
             <div>
-              <p className="eyebrow">Brain Dump</p>
-              <h2>Log the idea before it disappears.</h2>
+              <p className="eyebrow">Business Pulse</p>
+              <h2>What the money-side story looks like right now.</h2>
+            </div>
+            <span className="suggestions-card__tag">Manager read</span>
+          </div>
+
+          {conversionSnapshot ? (
+            <div className="metric-grid">
+              <div className="metric">
+                <p className="metric__label">OF Conversion</p>
+                <p className="metric__value">{conversionSnapshot.ofConversionLabel}</p>
+              </div>
+              <div className="metric">
+                <p className="metric__label">Profile To OF</p>
+                <p className="metric__value">{conversionSnapshot.profileToOfLabel}</p>
+              </div>
+              <div className="metric">
+                <p className="metric__label">New Subs</p>
+                <p className="metric__value">{conversionSnapshot.subsLabel}</p>
+              </div>
+              <div className="metric">
+                <p className="metric__label">Top Spender</p>
+                <p className="metric__value">{conversionSnapshot.topSpenderLabel}</p>
+              </div>
+            </div>
+          ) : (
+            <div className="brainstorm-empty">
+              <p>No conversion read yet.</p>
+              <p>Update the Conversion room and Home will start briefing you with real business context.</p>
+            </div>
+          )}
+        </article>
+
+        <article className="panel command-panel">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Priority Queue</p>
+              <h2>What is active in the workflow right now.</h2>
+            </div>
+            <span className="suggestions-card__tag">{priorityTasks.length} active</span>
+          </div>
+
+          <div className="tracker-list">
+            {priorityTasks.length ? (
+              priorityTasks.map((task) => (
+                <div className="task-card" key={task.id}>
+                  <div className="task-card__top">
+                    <h3>{task.title}</h3>
+                    <span className="task-card__platform">{task.status}</span>
+                  </div>
+                  <p className="task-card__due">{task.due}</p>
+                  <p className="task-card__note">{task.note}</p>
+                </div>
+              ))
+            ) : (
+              <div className="brainstorm-empty">
+                <p>No active workflow items yet.</p>
+                <p>Add a tracker task and Home will surface it here.</p>
+              </div>
+            )}
+          </div>
+        </article>
+      </section>
+
+      <section className="brainstorm-grid">
+        <article className="panel brainstorm-panel command-panel">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">Quick Capture</p>
+              <h2>Catch the next useful idea without leaving the command room.</h2>
             </div>
             <span className="suggestions-card__tag">Saved in this browser</span>
           </div>
@@ -231,13 +342,13 @@ export default function HomePage() {
           </div>
         </article>
 
-        <article className="panel brainstorm-panel">
+        <article className="panel brainstorm-panel command-panel">
           <div className="suggestions-card__header">
             <div>
-              <p className="eyebrow">Smart Nudge</p>
-              <h2>What this idea might turn into next.</h2>
+              <p className="eyebrow">Next Move</p>
+              <h2>What the manager thinks this should become.</h2>
             </div>
-            <span className="suggestions-card__tag">Suggestion preview</span>
+            <span className="suggestions-card__tag">Action direction</span>
           </div>
 
           <div className="suggestion-grid">
@@ -262,7 +373,33 @@ export default function HomePage() {
       </section>
 
       <section className="bottom-grid">
-        <article className="panel">
+        <article className="panel command-panel">
+          <div className="suggestions-card__header">
+            <div>
+              <p className="eyebrow">System Pulse</p>
+              <h2>Latest things the manager is paying attention to.</h2>
+            </div>
+            <span className="suggestions-card__tag">{recentEvents.length} recent</span>
+          </div>
+
+          <div className="event-list">
+            {recentEvents.length ? (
+              recentEvents.map((event) => (
+                <article className="event-card" key={event.id}>
+                  <p className="event-card__title">{event.title}</p>
+                  <p className="event-card__detail">{event.detail}</p>
+                </article>
+              ))
+            ) : (
+              <div className="brainstorm-empty">
+                <p>No system events yet.</p>
+                <p>Use the app a little more and the manager pulse will fill in here.</p>
+              </div>
+            )}
+          </div>
+        </article>
+
+        <article className="panel command-panel">
           <div className="suggestions-card__header">
             <div>
               <p className="eyebrow">Saved Brainstorms</p>


### PR DESCRIPTION
Closes #64\n\n## Summary\n- redesign Home around a manager briefing and command-room layout\n- surface workflow urgency, business pulse, recent system activity, and quick capture\n- keep brainstorm useful without letting it dominate the main room\n\n## Verification\n- npm run lint\n- curl -I http://localhost:3000/\n- curl -I http://localhost:3000/assistant