### PR TITLE
Add Instagram data pipeline and API routes

### DIFF
--- a/app/api/platforms/instagram/demographics/route.ts
+++ b/app/api/platforms/instagram/demographics/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { eq, and, desc } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { demographics } from "@/lib/db/schema";
+
+const PLATFORM = "instagram";
+
+export async function GET() {
+  // Get the most recent snapshot date
+  const latest = db
+    .select({ snapshotDate: demographics.snapshotDate })
+    .from(demographics)
+    .where(eq(demographics.platform, PLATFORM))
+    .orderBy(desc(demographics.snapshotDate))
+    .limit(1)
+    .all();
+
+  if (latest.length === 0) {
+    return NextResponse.json({
+      data: { cities: [], countries: [], genderAge: [] },
+      snapshotDate: null,
+      message: "No demographics data yet. Run a sync first, and note that Instagram requires 100+ followers for demographics."
+    });
+  }
+
+  const snapshotDate = latest[0].snapshotDate;
+
+  const rows = db
+    .select()
+    .from(demographics)
+    .where(
+      and(
+        eq(demographics.platform, PLATFORM),
+        eq(demographics.snapshotDate, snapshotDate)
+      )
+    )
+    .all();
+
+  const cities = rows
+    .filter((r) => r.metric === "city")
+    .map((r) => ({ key: r.key, value: r.value }))
+    .sort((a, b) => b.value - a.value);
+
+  const countries = rows
+    .filter((r) => r.metric === "country")
+    .map((r) => ({ key: r.key, value: r.value }))
+    .sort((a, b) => b.value - a.value);
+
+  const genderAge = rows
+    .filter((r) => r.metric === "gender_age")
+    .map((r) => ({ key: r.key, value: r.value }))
+    .sort((a, b) => b.value - a.value);
+
+  return NextResponse.json({
+    data: { cities, countries, genderAge },
+    snapshotDate
+  });
+}

--- a/app/api/platforms/instagram/insights/route.ts
+++ b/app/api/platforms/instagram/insights/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, gte, lte, asc } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { accountSnapshots } from "@/lib/db/schema";
+
+const PLATFORM = "instagram";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const days = Number(searchParams.get("days") ?? 30);
+
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+  const sinceDate = since.toISOString().split("T")[0];
+  const untilDate = new Date().toISOString().split("T")[0];
+
+  const snapshots = db
+    .select()
+    .from(accountSnapshots)
+    .where(
+      and(
+        eq(accountSnapshots.platform, PLATFORM),
+        gte(accountSnapshots.snapshotDate, sinceDate),
+        lte(accountSnapshots.snapshotDate, untilDate)
+      )
+    )
+    .orderBy(asc(accountSnapshots.snapshotDate))
+    .all();
+
+  // Calculate trend direction from first to last snapshot
+  let trend: "up" | "down" | "flat" = "flat";
+
+  if (snapshots.length >= 2) {
+    const first = snapshots[0].followerCount ?? 0;
+    const last = snapshots[snapshots.length - 1].followerCount ?? 0;
+    trend = last > first ? "up" : last < first ? "down" : "flat";
+  }
+
+  return NextResponse.json({
+    data: snapshots.map((s) => ({
+      date: s.snapshotDate,
+      followerCount: s.followerCount,
+      mediaCount: s.mediaCount,
+      reach: s.reach,
+      impressions: s.impressions,
+      profileViews: s.profileViews
+    })),
+    dateRange: { from: sinceDate, to: untilDate },
+    trend
+  });
+}

--- a/app/api/platforms/instagram/posts/route.ts
+++ b/app/api/platforms/instagram/posts/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { desc, eq, and, sql } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { posts, postInsights } from "@/lib/db/schema";
+
+const PLATFORM = "instagram";
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const limit = Math.min(Number(searchParams.get("limit") ?? DEFAULT_LIMIT), MAX_LIMIT);
+  const offset = Number(searchParams.get("offset") ?? 0);
+  const sortBy = searchParams.get("sort") ?? "published_at";
+  const sortDir = searchParams.get("dir") === "asc" ? "asc" : "desc";
+
+  // Get posts with their latest insights
+  const rows = db
+    .select({
+      id: posts.id,
+      platformPostId: posts.platformPostId,
+      caption: posts.caption,
+      mediaType: posts.mediaType,
+      permalink: posts.permalink,
+      publishedAt: posts.publishedAt,
+      impressions: postInsights.impressions,
+      reach: postInsights.reach,
+      engagement: postInsights.engagement,
+      saves: postInsights.saves,
+      likes: postInsights.likes,
+      comments: postInsights.comments,
+      snapshotDate: postInsights.snapshotDate
+    })
+    .from(posts)
+    .leftJoin(
+      postInsights,
+      and(
+        eq(postInsights.postId, posts.id),
+        eq(
+          postInsights.snapshotDate,
+          db
+            .select({ maxDate: sql<string>`MAX(${postInsights.snapshotDate})` })
+            .from(postInsights)
+            .where(eq(postInsights.postId, posts.id))
+        )
+      )
+    )
+    .where(eq(posts.platform, PLATFORM))
+    .orderBy(
+      sortDir === "asc"
+        ? sql`${getSortColumn(sortBy)} ASC`
+        : sql`${getSortColumn(sortBy)} DESC`
+    )
+    .limit(limit)
+    .offset(offset)
+    .all();
+
+  const total = db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(posts)
+    .where(eq(posts.platform, PLATFORM))
+    .all()[0].count;
+
+  return NextResponse.json({
+    data: rows,
+    pagination: {
+      total,
+      limit,
+      offset,
+      hasMore: offset + limit < total
+    }
+  });
+}
+
+function getSortColumn(sortBy: string) {
+  switch (sortBy) {
+    case "engagement": return postInsights.engagement;
+    case "reach": return postInsights.reach;
+    case "impressions": return postInsights.impressions;
+    case "saves": return postInsights.saves;
+    case "likes": return postInsights.likes;
+    case "comments": return postInsights.comments;
+    default: return posts.publishedAt;
+  }
+}

--- a/app/api/sync/instagram/route.ts
+++ b/app/api/sync/instagram/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { syncAllInstagram } from "@/lib/sync/instagram";
+import { InstagramAuthError, InstagramRateLimitError } from "@/lib/platforms/instagram";
+
+export async function POST() {
+  try {
+    const result = await syncAllInstagram();
+    return NextResponse.json({ status: "ok", result });
+  } catch (error) {
+    if (error instanceof InstagramAuthError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+
+    if (error instanceof InstagramRateLimitError) {
+      return NextResponse.json({ error: error.message }, { status: 429 });
+    }
+
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/lib/sync/instagram.ts
+++ b/lib/sync/instagram.ts
@@ -1,0 +1,281 @@
+import { eq, and, sql } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { posts, postInsights, accountSnapshots, demographics } from "@/lib/db/schema";
+import {
+  getMedia,
+  getPostInsights,
+  getAccountInfo,
+  getAccountInsights,
+  getDemographics
+} from "@/lib/platforms/instagram";
+
+const PLATFORM = "instagram";
+
+function todayDate(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+// ── Posts + Per-Post Insights ────────────────────────────────────────
+
+export interface SyncPostsResult {
+  postsUpserted: number;
+  insightsUpserted: number;
+  pagesProcessed: number;
+}
+
+export async function syncInstagramPosts(maxPages = 10): Promise<SyncPostsResult> {
+  let cursor: string | undefined;
+  let postsUpserted = 0;
+  let insightsUpserted = 0;
+  let pagesProcessed = 0;
+  const today = todayDate();
+
+  for (let page = 0; page < maxPages; page++) {
+    const mediaPage = await getMedia(cursor);
+    pagesProcessed++;
+
+    for (const media of mediaPage.data) {
+      // Upsert post
+      const existing = db
+        .select()
+        .from(posts)
+        .where(and(eq(posts.platform, PLATFORM), eq(posts.platformPostId, media.id)))
+        .all();
+
+      let postId: number;
+
+      if (existing.length > 0) {
+        postId = existing[0].id;
+        db.update(posts)
+          .set({
+            caption: media.caption,
+            mediaType: media.mediaType,
+            permalink: media.permalink,
+            publishedAt: media.timestamp
+          })
+          .where(eq(posts.id, postId))
+          .run();
+      } else {
+        const result = db.insert(posts)
+          .values({
+            platformPostId: media.id,
+            platform: PLATFORM,
+            caption: media.caption,
+            mediaType: media.mediaType,
+            permalink: media.permalink,
+            publishedAt: media.timestamp
+          })
+          .run();
+        postId = Number(result.lastInsertRowid);
+      }
+
+      postsUpserted++;
+
+      // Fetch and upsert insights for this post
+      try {
+        const insights = await getPostInsights(media.id);
+
+        const existingInsight = db
+          .select()
+          .from(postInsights)
+          .where(and(eq(postInsights.postId, postId), eq(postInsights.snapshotDate, today)))
+          .all();
+
+        if (existingInsight.length > 0) {
+          db.update(postInsights)
+            .set({
+              impressions: insights.impressions,
+              reach: insights.reach,
+              engagement: insights.engagement,
+              saves: insights.saved,
+              likes: media.likeCount,
+              comments: media.commentsCount
+            })
+            .where(eq(postInsights.id, existingInsight[0].id))
+            .run();
+        } else {
+          db.insert(postInsights)
+            .values({
+              postId,
+              snapshotDate: today,
+              impressions: insights.impressions,
+              reach: insights.reach,
+              engagement: insights.engagement,
+              saves: insights.saved,
+              likes: media.likeCount,
+              comments: media.commentsCount
+            })
+            .run();
+        }
+
+        insightsUpserted++;
+      } catch {
+        // Some media types (stories, reels) may not support all insight metrics.
+        // Skip and continue rather than failing the whole sync.
+      }
+    }
+
+    if (!mediaPage.nextCursor) {
+      break;
+    }
+
+    cursor = mediaPage.nextCursor;
+  }
+
+  return { postsUpserted, insightsUpserted, pagesProcessed };
+}
+
+// ── Account Snapshots ────────────────────────────────────────────────
+
+export interface SyncAccountResult {
+  snapshotsUpserted: number;
+}
+
+export async function syncInstagramAccount(): Promise<SyncAccountResult> {
+  const today = todayDate();
+  const accountInfo = await getAccountInfo();
+
+  // Fetch the last 7 days of account insights
+  const since = new Date();
+  since.setDate(since.getDate() - 7);
+  const until = new Date();
+
+  const insights = await getAccountInsights(since, until);
+
+  let snapshotsUpserted = 0;
+
+  for (const insight of insights) {
+    const existing = db
+      .select()
+      .from(accountSnapshots)
+      .where(and(eq(accountSnapshots.platform, PLATFORM), eq(accountSnapshots.snapshotDate, insight.date)))
+      .all();
+
+    if (existing.length > 0) {
+      db.update(accountSnapshots)
+        .set({
+          followerCount: insight.followerCount,
+          reach: insight.reach,
+          impressions: insight.impressions,
+          mediaCount: accountInfo.mediaCount
+        })
+        .where(eq(accountSnapshots.id, existing[0].id))
+        .run();
+    } else {
+      db.insert(accountSnapshots)
+        .values({
+          platform: PLATFORM,
+          snapshotDate: insight.date,
+          followerCount: insight.followerCount,
+          reach: insight.reach,
+          impressions: insight.impressions,
+          mediaCount: accountInfo.mediaCount
+        })
+        .run();
+    }
+
+    snapshotsUpserted++;
+  }
+
+  // Also store today's snapshot with current follower count even if API insights
+  // haven't rolled over yet
+  const todayExists = db
+    .select()
+    .from(accountSnapshots)
+    .where(and(eq(accountSnapshots.platform, PLATFORM), eq(accountSnapshots.snapshotDate, today)))
+    .all();
+
+  if (todayExists.length === 0) {
+    db.insert(accountSnapshots)
+      .values({
+        platform: PLATFORM,
+        snapshotDate: today,
+        followerCount: accountInfo.followersCount,
+        mediaCount: accountInfo.mediaCount
+      })
+      .run();
+    snapshotsUpserted++;
+  }
+
+  return { snapshotsUpserted };
+}
+
+// ── Demographics ─────────────────────────────────────────────────────
+
+export interface SyncDemographicsResult {
+  entriesUpserted: number;
+}
+
+export async function syncInstagramDemographics(): Promise<SyncDemographicsResult> {
+  const today = todayDate();
+  let entriesUpserted = 0;
+
+  try {
+    const demo = await getDemographics();
+
+    const allEntries: Array<{ metric: string; key: string; value: number }> = [
+      ...demo.cities.map((e) => ({ metric: "city" as const, ...e })),
+      ...demo.countries.map((e) => ({ metric: "country" as const, ...e })),
+      ...demo.genderAge.map((e) => ({ metric: "gender_age" as const, ...e }))
+    ];
+
+    for (const entry of allEntries) {
+      const existing = db
+        .select()
+        .from(demographics)
+        .where(
+          and(
+            eq(demographics.platform, PLATFORM),
+            eq(demographics.snapshotDate, today),
+            eq(demographics.metric, entry.metric),
+            eq(demographics.key, entry.key)
+          )
+        )
+        .all();
+
+      if (existing.length > 0) {
+        db.update(demographics)
+          .set({ value: entry.value })
+          .where(eq(demographics.id, existing[0].id))
+          .run();
+      } else {
+        db.insert(demographics)
+          .values({
+            platform: PLATFORM,
+            snapshotDate: today,
+            metric: entry.metric,
+            key: entry.key,
+            value: entry.value
+          })
+          .run();
+      }
+
+      entriesUpserted++;
+    }
+  } catch {
+    // Demographics require 100+ followers. If the account doesn't have enough,
+    // the API returns an error. Skip gracefully.
+  }
+
+  return { entriesUpserted };
+}
+
+// ── Full sync orchestrator ───────────────────────────────────────────
+
+export interface SyncAllResult {
+  posts: SyncPostsResult;
+  account: SyncAccountResult;
+  demographics: SyncDemographicsResult;
+}
+
+export async function syncAllInstagram(): Promise<SyncAllResult> {
+  const postsResult = await syncInstagramPosts();
+  const accountResult = await syncInstagramAccount();
+  const demographicsResult = await syncInstagramDemographics();
+
+  return {
+    posts: postsResult,
+    account: accountResult,
+    demographics: demographicsResult
+  };
+}


### PR DESCRIPTION
## Summary
- Sync orchestrator that fetches all Instagram data (posts, insights, account metrics, demographics) and stores in SQLite with deduplication
- 4 new API routes: sync trigger, posts listing, account insights, demographics
- Graceful error handling for unsupported media types and accounts with <100 followers

## API Endpoints
- `POST /api/sync/instagram` — triggers full data sync
- `GET /api/platforms/instagram/posts?limit=25&offset=0&sort=engagement&dir=desc` — paginated posts with latest insights
- `GET /api/platforms/instagram/insights?days=30` — account snapshots with trend
- `GET /api/platforms/instagram/demographics` — latest audience breakdown

## Test plan
- [x] Build passes with no type errors
- [x] All routes compile and register in Next.js

Closes #78, closes #79, closes #80