### PR TITLE
Replace hero sections with simple page titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ coverage
 *.db-journal
 *.db-wal
 data/
+.env
 .env.local

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -165,27 +165,17 @@ export default function AnalyticsPage() {
 
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Analytics Dashboard</p>
-          <h1>Real performance data from your connected Instagram account.</h1>
-          <p className="lede">
-            Synced from the Instagram Graph API. Posts, engagement, follower
-            trends, audience demographics, and best posting times — all in one place.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">Instagram</span>
-          <button
-            className="hero__cta"
-            type="button"
-            disabled={syncing}
-            onClick={handleSync}
-          >
-            {syncing ? "Syncing..." : "Sync Now"}
-          </button>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Analytics</h1>
+        <button
+          className="page-header__action"
+          type="button"
+          disabled={syncing}
+          onClick={handleSync}
+        >
+          {syncing ? "Syncing..." : "Sync Now"}
+        </button>
+      </header>
 
       {error && (
         <div className="analytics-error panel">

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -188,30 +188,9 @@ export default function AssistantPage() {
 
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Assistant Room</p>
-          <h1>Talk to the manager-style AI that is starting to learn your business.</h1>
-          <p className="lede">
-            This is the first real conversation room. It uses your saved assistant memory,
-            recent app events, and your last conversion snapshot to talk more like an
-            actual manager instead of a generic helper.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">{memory.assistantName}</span>
-          <p>
-            Current mode: {memory.tone} · {memory.focus} focus
-          </p>
-          {conversionSnapshot ? (
-            <p className="hero__save-state">
-              Leading with {conversionSnapshot.ofConversionLabel} OF conversion from{" "}
-              {conversionSnapshot.pageViewsLabel} OF page views.
-            </p>
-          ) : null}
-          <p className="hero__save-state">{events.length} recent events remembered</p>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Assistant</h1>
+      </header>
 
       <section className="brainstorm-grid">
         <article className="panel assistant-room">

--- a/app/conversion/page.tsx
+++ b/app/conversion/page.tsx
@@ -78,25 +78,10 @@ export default function ConversionPage() {
 
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Conversion Room</p>
-          <h1>See whether your Instagram content is actually translating into OnlyFans results.</h1>
-          <p className="lede">
-            This room is about the funnel from attention to money. Plug in the OF-side
-            numbers you already know, and this page will turn them into a clearer
-            picture of how your Instagram traffic is translating into subscribers and spending signals.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">Business layer</span>
-          <p>
-            Insights tells you how content performs. Conversion tells you whether
-            that attention is actually moving toward OF traffic and paid action.
-          </p>
-          <p className="hero__save-state">{saveState}</p>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Conversion</h1>
+        {saveState ? <p className="page-header__status">{saveState}</p> : null}
+      </header>
 
       <section className="overview-grid">
         {summary.stats.map((signal) => (

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -61,24 +61,9 @@ export default function CreatorPage() {
 
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Creator Foundation</p>
-          <h1>Set up the active creator profile and the Instagram account details this workspace will eventually connect to.</h1>
-          <p className="lede">
-            This page is now the account setup room behind the profile menu. It tells
-            the app which creator is active, keeps saved data scoped to that creator,
-            and gives us a place to prepare the Instagram connection setup.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">Foundation</span>
-          <p>
-            This is not full live login yet. It is the groundwork that makes later
-            authentication and Instagram sync much cleaner to build.
-          </p>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Creator Setup</h1>
+      </header>
 
       <section className="creator-grid">
         <article className="panel">

--- a/app/globals.css
+++ b/app/globals.css
@@ -2443,6 +2443,47 @@ li + li {
   }
 }
 
+/* ── Page Header ──────────────────────────────────────────────────── */
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-title {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  color: var(--lime-soft);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.page-header__action {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid rgba(182, 255, 39, 0.3);
+  background: rgba(182, 255, 39, 0.1);
+  color: var(--lime-soft);
+  font: inherit;
+  font-weight: 700;
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+
+.page-header__action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.page-header__status {
+  margin: 0;
+  color: rgba(248, 255, 213, 0.5);
+  font-size: 0.82rem;
+}
+
 /* ── Analytics Dashboard ──────────────────────────────────────────── */
 
 .analytics-error {

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -4,23 +4,9 @@ import { overviewStats, platformCards, suggestions } from "@/lib/insights";
 export default function InsightsPage() {
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Instagram Insights</p>
-          <h1>One dashboard to track what your Instagram content is actually doing.</h1>
-          <p className="lede">
-            This first version focuses on Instagram performance, spots what is
-            working, and gives you suggestions for what to try next.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">MVP</span>
-          <p>
-            Start simple, learn fast, then add account connections, uploads, and
-            smarter recommendations later.
-          </p>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Insights</h1>
+      </header>
 
       <section className="overview-grid">
         {overviewStats.map((stat) => (

--- a/app/insights/suggestions/page.tsx
+++ b/app/insights/suggestions/page.tsx
@@ -31,23 +31,9 @@ const focusMap: Record<string, string[]> = {
 export default function SuggestionsPage() {
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Suggestions Engine</p>
-          <h1>Recommended next moves based on the signals already showing up in your Instagram content.</h1>
-          <p className="lede">
-            This page turns patterns from your insights into action ideas, so you
-            do not have to stare at numbers and guess what they mean.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">Decision support</span>
-          <p>
-            These suggestions are generated from the current insights data model.
-            As the app gets real data later, the recommendations can get smarter too.
-          </p>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Suggestions</h1>
+      </header>
 
       <section className="overview-grid">
         <article className="stat-card panel">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -172,23 +172,9 @@ export default function HomePage() {
 
   return (
     <main className="page">
-      <section className="hero panel command-hero">
-        <div>
-          <p className="eyebrow">Command Room</p>
-          <h1>See what matters now, what is moving, and what the manager wants next.</h1>
-          <p className="lede">
-            Home should feel like the briefing board for the whole app. Start here for the
-            manager read, workflow urgency, business pulse, and a quick place to capture ideas.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">Manager briefing</span>
-          <p>
-            Current operator: {assistantMemory.assistantName}
-          </p>
-          <p className="hero__save-state">{assistantMemory.currentPriority}</p>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Home</h1>
+      </header>
 
       <section className="panel assistant-card command-brief">
         <div className="assistant-card__copy">

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 const protectionCards = [
   {
     title: "Creator data is separated",
@@ -35,28 +33,9 @@ const nextLocks = [
 export default function SecurityPage() {
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Safety and Security</p>
-          <h1>Protect creator data first, then connect real accounts.</h1>
-          <p className="lede">
-            Think of this room like the lock-and-keys checklist for the app. It
-            explains what is already protecting creator data, what is still only local,
-            and what must be upgraded before live Instagram connection work begins.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">Safety first</span>
-          <p>
-            Authentication proves who the creator is, authorization controls what she
-            can access, and encryption helps keep sensitive data unreadable if it is
-            intercepted or stored in the wrong place.
-          </p>
-          <Link className="hero__cta" href="/creator">
-            Open Creator Setup
-          </Link>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Safety and Security</h1>
+      </header>
 
       <section className="overview-grid">
         {protectionCards.map((card) => (

--- a/app/tracker/page.tsx
+++ b/app/tracker/page.tsx
@@ -127,24 +127,10 @@ export default function TrackerPage() {
 
   return (
     <main className="page">
-      <section className="hero panel">
-        <div>
-          <p className="eyebrow">Post Progress Tracker</p>
-          <h1>A day-to-day operations room for planning, making, and posting Instagram content.</h1>
-          <p className="lede">
-            Use this space to track where each piece of content stands so you can
-            see what is just an idea, what is being made, and what is ready to post.
-          </p>
-        </div>
-        <div className="hero__note">
-          <span className="hero__badge">Workflow</span>
-          <p>
-            This room now acts like a real content board, not just a mockup. Add tasks,
-            move them forward, and let the assistant learn from your workflow.
-          </p>
-          <p className="hero__save-state">{saveState}</p>
-        </div>
-      </section>
+      <header className="page-header">
+        <h1 className="page-title">Tracker</h1>
+        {saveState ? <p className="page-header__status">{saveState}</p> : null}
+      </header>
 
       <section className="overview-grid">
         {todayStats.map((stat) => (

--- a/components/topbar.tsx
+++ b/components/topbar.tsx
@@ -26,13 +26,12 @@ export function Topbar() {
         Maddie HQ
       </Link>
       <nav className="topbar__nav" aria-label="Main navigation">
-        <Link href="/good-morning">Good Morning</Link>
-        <Link href="/assistant">Assistant</Link>
         <Link href="/">Home</Link>
-        <Link href="/insights">Insights</Link>
         <Link href="/analytics">Analytics</Link>
+        <Link href="/insights">Insights</Link>
         <Link href="/tracker">Tracker</Link>
         <Link href="/conversion">Conversion</Link>
+        <Link href="/assistant">Assistant</Link>
       </nav>
       <div className="topbar__profile-menu" ref={menuRef}>
         <button


### PR DESCRIPTION
## Summary
- Remove oversized hero banners from all pages, replace with clean page-title headers
- Remove Good Morning link from navigation
- Reorder nav: Home, Analytics, Insights, Tracker, Conversion, Assistant
- Add `.env` to `.gitignore`

## Test plan
- [x] Build passes
- [x] All pages render with new headers