### PR TITLE
Add video transcription and key frame analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ INSTAGRAM_INITIAL_TOKEN=
 
 ANTHROPIC_API_KEY=
 
+# ── OpenAI (Audio Transcription) ──────────────────────────────────────
+# Get your API key at https://platform.openai.com/api-keys
+# Used for Whisper speech-to-text on video posts
+
+OPENAI_API_KEY=
+
 # ── Reddit ────────────────────────────────────────────────────────────
 # Create a "script" type app at https://www.reddit.com/prefs/apps
 # The redirect URI can be http://localhost:3000 (not used for script apps)

--- a/app/api/analyze/instagram/video/route.ts
+++ b/app/api/analyze/instagram/video/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { processVideoPosts } from "@/lib/ai/video-analysis";
+
+export async function POST() {
+  try {
+    const result = await processVideoPosts();
+    return NextResponse.json({ status: "ok", result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -43,17 +43,33 @@ export default function InsightsPage() {
     setAnalyzing(true);
     setError(null);
     try {
-      const res = await fetch("/api/analyze/instagram", {
+      // Step 1: Run base analysis (vision + caption) on unanalyzed posts
+      const analyzeRes = await fetch("/api/analyze/instagram", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "full" })
+        body: JSON.stringify({ action: "analyze" })
       });
-      if (!res.ok) {
-        const json = await res.json();
+      if (!analyzeRes.ok) {
+        const json = await analyzeRes.json();
         setError(json.error ?? "Analysis failed");
         return;
       }
-      const json = await res.json();
+
+      // Step 2: Process videos (transcription + key frames)
+      await fetch("/api/analyze/instagram/video", { method: "POST" });
+
+      // Step 3: Generate the pattern report
+      const reportRes = await fetch("/api/analyze/instagram", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "report" })
+      });
+      if (!reportRes.ok) {
+        const json = await reportRes.json();
+        setError(json.error ?? "Report generation failed");
+        return;
+      }
+      const json = await reportRes.json();
       setReport(json.report ?? null);
     } catch {
       setError("Analysis failed. Make sure ANTHROPIC_API_KEY is set in .env");

--- a/drizzle/0002_outgoing_silk_fever.sql
+++ b/drizzle/0002_outgoing_silk_fever.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `post_analysis` ADD `transcript` text;--> statement-breakpoint
+ALTER TABLE `post_analysis` ADD `spoken_hook` text;--> statement-breakpoint
+ALTER TABLE `post_analysis` ADD `key_frame_analysis` text;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,675 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "98f1956e-71f0-461b-8e54-ab14cee13948",
+  "prevId": "4fe8a4e0-4d21-4156-9397-b7f7e8f36835",
+  "tables": {
+    "account_snapshots": {
+      "name": "account_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "follower_count": {
+          "name": "follower_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_count": {
+          "name": "media_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reach": {
+          "name": "reach",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_views": {
+          "name": "profile_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_snapshots_platform_date_idx": {
+          "name": "account_snapshots_platform_date_idx",
+          "columns": [
+            "platform",
+            "snapshot_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_insights": {
+      "name": "content_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "report_json": {
+          "name": "report_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "posts_analyzed": {
+          "name": "posts_analyzed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "demographics": {
+      "name": "demographics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "demographics_unique_idx": {
+          "name": "demographics_unique_idx",
+          "columns": [
+            "platform",
+            "snapshot_date",
+            "metric",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "platforms": {
+      "name": "platforms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "platforms_platform_account_idx": {
+          "name": "platforms_platform_account_idx",
+          "columns": [
+            "platform",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_analysis": {
+      "name": "post_analysis",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "setting": {
+          "name": "setting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lighting": {
+          "name": "lighting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "face_visible": {
+          "name": "face_visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text_overlay": {
+          "name": "text_overlay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visual_style": {
+          "name": "visual_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_length": {
+          "name": "caption_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hook_type": {
+          "name": "hook_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cta_present": {
+          "name": "cta_present",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cta_type": {
+          "name": "cta_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caption_tone": {
+          "name": "caption_tone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji_count": {
+          "name": "emoji_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hashtag_count": {
+          "name": "hashtag_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spoken_hook": {
+          "name": "spoken_hook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_frame_analysis": {
+          "name": "key_frame_analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_analysis": {
+          "name": "raw_analysis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analyzed_at": {
+          "name": "analyzed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_analysis_post_idx": {
+          "name": "post_analysis_post_idx",
+          "columns": [
+            "post_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "post_analysis_post_id_posts_id_fk": {
+          "name": "post_analysis_post_id_posts_id_fk",
+          "tableFrom": "post_analysis",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_insights": {
+      "name": "post_insights",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reach": {
+          "name": "reach",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engagement": {
+          "name": "engagement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "saves": {
+          "name": "saves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "likes": {
+          "name": "likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "shares": {
+          "name": "shares",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upvote_ratio": {
+          "name": "upvote_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "post_insights_post_date_idx": {
+          "name": "post_insights_post_date_idx",
+          "columns": [
+            "post_id",
+            "snapshot_date"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "post_insights_post_id_posts_id_fk": {
+          "name": "post_insights_post_id_posts_id_fk",
+          "tableFrom": "post_insights",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "platform_post_id": {
+          "name": "platform_post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_url": {
+          "name": "media_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permalink": {
+          "name": "permalink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "posts_platform_post_idx": {
+          "name": "posts_platform_post_idx",
+          "columns": [
+            "platform",
+            "platform_post_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1774640568673,
       "tag": "0001_superb_maginty",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1774643096311,
+      "tag": "0002_outgoing_silk_fever",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/ai/analyze-content.ts
+++ b/lib/ai/analyze-content.ts
@@ -3,7 +3,7 @@ import { eq, isNull, desc, and } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { posts, postInsights, postAnalysis, contentInsights } from "@/lib/db/schema";
 
-const client = new Anthropic();
+function getClient() { return new Anthropic(); }
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -58,7 +58,7 @@ export interface ContentReport {
 // ── Single post analysis ─────────────────────────────────────────────
 
 async function analyzePostVisual(imageUrl: string): Promise<VisualAnalysis> {
-  const response = await client.messages.create({
+  const response = await getClient().messages.create({
     model: "claude-sonnet-4-20250514",
     max_tokens: 500,
     messages: [{
@@ -212,6 +212,9 @@ export async function generateContentReport(): Promise<ContentReport> {
       ctaPresent: postAnalysis.ctaPresent,
       captionTone: postAnalysis.captionTone,
       emojiCount: postAnalysis.emojiCount,
+      transcript: postAnalysis.transcript,
+      spokenHook: postAnalysis.spokenHook,
+      keyFrameAnalysis: postAnalysis.keyFrameAnalysis,
       impressions: postInsights.impressions,
       reach: postInsights.reach,
       engagement: postInsights.engagement,
@@ -248,7 +251,7 @@ export async function generateContentReport(): Promise<ContentReport> {
     byCaptionTone: groupAndAverage(rows, "captionTone"),
     topPosts: rows
       .sort((a, b) => (b.engagement ?? 0) - (a.engagement ?? 0))
-      .slice(0, 5)
+      .slice(0, 10)
       .map((r) => ({
         caption: r.caption?.slice(0, 80),
         mediaType: r.mediaType,
@@ -256,13 +259,16 @@ export async function generateContentReport(): Promise<ContentReport> {
         lighting: r.lighting,
         hookType: r.hookType,
         captionTone: r.captionTone,
+        spokenHook: r.spokenHook,
+        transcript: r.transcript?.slice(0, 150),
+        keyFrameHighlights: parseKeyFrameHighlights(r.keyFrameAnalysis),
         engagement: r.engagement,
         reach: r.reach,
         saves: r.saves
       })),
     bottomPosts: rows
       .sort((a, b) => (a.engagement ?? 0) - (b.engagement ?? 0))
-      .slice(0, 5)
+      .slice(0, 10)
       .map((r) => ({
         caption: r.caption?.slice(0, 80),
         mediaType: r.mediaType,
@@ -270,13 +276,16 @@ export async function generateContentReport(): Promise<ContentReport> {
         lighting: r.lighting,
         hookType: r.hookType,
         captionTone: r.captionTone,
+        spokenHook: r.spokenHook,
+        transcript: r.transcript?.slice(0, 150),
+        keyFrameHighlights: parseKeyFrameHighlights(r.keyFrameAnalysis),
         engagement: r.engagement,
         reach: r.reach,
         saves: r.saves
       }))
   };
 
-  const response = await client.messages.create({
+  const response = await getClient().messages.create({
     model: "claude-sonnet-4-20250514",
     max_tokens: 2000,
     messages: [{
@@ -389,7 +398,7 @@ export async function elaboratePattern(pattern: { title: string; description: st
     .limit(20)
     .all();
 
-  const response = await client.messages.create({
+  const response = await getClient().messages.create({
     model: "claude-sonnet-4-20250514",
     max_tokens: 1500,
     messages: [{
@@ -427,6 +436,16 @@ Write in a direct, strategic tone. Be specific — reference actual captions and
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+function parseKeyFrameHighlights(json: string | null): string | null {
+  if (!json || json === "{}") return null;
+  try {
+    const parsed = JSON.parse(json);
+    return `${parsed.appearance ?? ""} | ${parsed.location ?? ""} | ${parsed.energy ?? ""} energy`.trim();
+  } catch {
+    return null;
+  }
+}
 
 function groupAndAverage(
   rows: Array<Record<string, unknown>>,

--- a/lib/ai/video-analysis.ts
+++ b/lib/ai/video-analysis.ts
@@ -1,0 +1,260 @@
+import { execFileSync } from "child_process";
+import { mkdirSync, existsSync, readFileSync, unlinkSync, readdirSync, writeFileSync } from "fs";
+import { join } from "path";
+import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
+import { eq, and, isNotNull } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { posts, postAnalysis } from "@/lib/db/schema";
+
+function getAnthropic() { return new Anthropic(); }
+function getOpenAI() { return new OpenAI(); }
+
+const TMP_DIR = "./data/tmp-video";
+
+function ensureTmpDir() {
+  if (!existsSync(TMP_DIR)) {
+    mkdirSync(TMP_DIR, { recursive: true });
+  }
+}
+
+function cleanupFile(path: string) {
+  try { if (existsSync(path)) unlinkSync(path); } catch { /* ignore */ }
+}
+
+function cleanupDir(dir: string) {
+  try {
+    if (existsSync(dir)) {
+      for (const file of readdirSync(dir)) {
+        cleanupFile(join(dir, file));
+      }
+    }
+  } catch { /* ignore */ }
+}
+
+// ── Audio Transcription ──────────────────────────────────────────────
+
+async function downloadVideo(url: string, outputPath: string): Promise<void> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to download video: ${response.status}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  writeFileSync(outputPath, buffer);
+}
+
+function extractAudio(videoPath: string, audioPath: string): void {
+  execFileSync("ffmpeg", ["-i", videoPath, "-vn", "-acodec", "libmp3lame", "-q:a", "4", "-y", audioPath], {
+    timeout: 30000,
+    stdio: "pipe"
+  });
+}
+
+async function transcribeAudio(audioPath: string): Promise<string> {
+  const file = readFileSync(audioPath);
+  const audioFile = new File([file], "audio.mp3", { type: "audio/mpeg" });
+
+  const response = await getOpenAI().audio.transcriptions.create({
+    model: "whisper-1",
+    file: audioFile,
+    response_format: "text"
+  });
+
+  return response.trim();
+}
+
+function extractSpokenHook(transcript: string): string {
+  const words = transcript.split(/\s+/).slice(0, 15);
+  return words.join(" ") + (transcript.split(/\s+/).length > 15 ? "..." : "");
+}
+
+// ── Key Frame Extraction ─────────────────────────────────────────────
+
+function getVideoDuration(videoPath: string): number {
+  const output = execFileSync("ffprobe", [
+    "-v", "quiet",
+    "-show_entries", "format=duration",
+    "-of", "csv=p=0",
+    videoPath
+  ], { timeout: 10000, stdio: "pipe" }).toString().trim();
+
+  return parseFloat(output) || 0;
+}
+
+function extractKeyFrames(videoPath: string, outputDir: string, count = 5): string[] {
+  mkdirSync(outputDir, { recursive: true });
+  const duration = getVideoDuration(videoPath);
+
+  if (duration <= 0) return [];
+
+  const timestamps = Array.from({ length: count }, (_, i) => {
+    if (i === 0) return 0.5;
+    if (i === count - 1) return Math.max(0.5, duration - 0.5);
+    return (duration * i) / (count - 1);
+  });
+
+  const framePaths: string[] = [];
+
+  for (let i = 0; i < timestamps.length; i++) {
+    const framePath = join(outputDir, `frame_${i}.jpg`);
+    try {
+      execFileSync("ffmpeg", [
+        "-ss", String(timestamps[i]),
+        "-i", videoPath,
+        "-frames:v", "1",
+        "-q:v", "2",
+        "-y", framePath
+      ], { timeout: 10000, stdio: "pipe" });
+
+      if (existsSync(framePath)) {
+        framePaths.push(framePath);
+      }
+    } catch {
+      // Skip frame if extraction fails
+    }
+  }
+
+  return framePaths;
+}
+
+async function analyzeKeyFrames(framePaths: string[]): Promise<string> {
+  if (framePaths.length === 0) return "{}";
+
+  const imageContent: Array<
+    | { type: "image"; source: { type: "base64"; media_type: "image/jpeg"; data: string } }
+    | { type: "text"; text: string }
+  > = [];
+
+  for (let i = 0; i < framePaths.length; i++) {
+    const imageData = readFileSync(framePaths[i]).toString("base64");
+    imageContent.push({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: imageData }
+    });
+    imageContent.push({
+      type: "text",
+      text: `Frame ${i + 1} of ${framePaths.length}${i === 0 ? " (opening)" : i === framePaths.length - 1 ? " (ending)" : ""}`
+    });
+  }
+
+  imageContent.push({
+    type: "text",
+    text: `These are ${framePaths.length} key frames from an Instagram reel. Analyze them as a sequence and return ONLY a JSON object:
+{
+  "appearance": "what the creator is wearing, hair, makeup — be specific",
+  "location": "where they are — be specific about the setting",
+  "poses": "how they're positioned/moving across the frames",
+  "scene_changes": "do the scenes change? describe transitions",
+  "energy": "low/medium/high — overall vibe of the visual content",
+  "props_or_objects": "anything notable in the frame besides the creator",
+  "visual_narrative": "1-2 sentences describing the visual story arc from first to last frame"
+}
+
+Return only the JSON, no other text.`
+  });
+
+  const response = await getAnthropic().messages.create({
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 600,
+    messages: [{ role: "user", content: imageContent }]
+  });
+
+  const text = response.content[0].type === "text" ? response.content[0].text : "";
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  return jsonMatch ? jsonMatch[0] : "{}";
+}
+
+// ── Batch Processing ─────────────────────────────────────────────────
+
+export interface VideoAnalysisResult {
+  transcribed: number;
+  framesAnalyzed: number;
+  skipped: number;
+  errors: number;
+}
+
+export async function processVideoPosts(limit = 50): Promise<VideoAnalysisResult> {
+  ensureTmpDir();
+
+  // Find video posts that have a media_url and an analysis row but no transcript
+  const videoPosts = db
+    .select({
+      id: posts.id,
+      platformPostId: posts.platformPostId,
+      mediaUrl: posts.mediaUrl,
+      analysisId: postAnalysis.id,
+      transcript: postAnalysis.transcript
+    })
+    .from(posts)
+    .innerJoin(postAnalysis, eq(postAnalysis.postId, posts.id))
+    .where(
+      and(
+        eq(posts.mediaType, "VIDEO"),
+        isNotNull(posts.mediaUrl)
+      )
+    )
+    .limit(limit * 2) // fetch extra since we filter below
+    .all()
+    .filter((p) => !p.transcript)
+    .slice(0, limit);
+
+  let transcribed = 0;
+  let framesAnalyzed = 0;
+  let skipped = 0;
+  let errors = 0;
+
+  for (const post of videoPosts) {
+    if (!post.mediaUrl) { skipped++; continue; }
+
+    const videoPath = join(TMP_DIR, `${post.platformPostId}.mp4`);
+    const audioPath = join(TMP_DIR, `${post.platformPostId}.mp3`);
+    const framesDir = join(TMP_DIR, `frames_${post.platformPostId}`);
+
+    try {
+      // Download video
+      await downloadVideo(post.mediaUrl, videoPath);
+
+      // Transcribe audio
+      let transcript = "";
+      let spokenHook = "";
+      try {
+        extractAudio(videoPath, audioPath);
+        transcript = await transcribeAudio(audioPath);
+        spokenHook = extractSpokenHook(transcript);
+        transcribed++;
+      } catch {
+        transcript = "(no audio detected)";
+      }
+
+      // Extract and analyze key frames
+      let keyFrameAnalysis = "{}";
+      try {
+        const framePaths = extractKeyFrames(videoPath, framesDir, 5);
+        if (framePaths.length > 0) {
+          keyFrameAnalysis = await analyzeKeyFrames(framePaths);
+          framesAnalyzed++;
+        }
+        cleanupDir(framesDir);
+      } catch {
+        // Frame analysis failed
+      }
+
+      // Update post_analysis
+      db.update(postAnalysis)
+        .set({ transcript, spokenHook, keyFrameAnalysis })
+        .where(eq(postAnalysis.postId, post.id))
+        .run();
+
+    } catch {
+      errors++;
+    } finally {
+      cleanupFile(videoPath);
+      cleanupFile(audioPath);
+      cleanupDir(framesDir);
+    }
+  }
+
+  return { transcribed, framesAnalyzed, skipped, errors };
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -55,6 +55,10 @@ export const postAnalysis = sqliteTable("post_analysis", {
   captionTone: text("caption_tone"), // "casual" | "provocative" | "informational" | "personal"
   emojiCount: integer("emoji_count"),
   hashtagCount: integer("hashtag_count"),
+  // Video analysis
+  transcript: text("transcript"),
+  spokenHook: text("spoken_hook"), // first ~15 words of the transcript
+  keyFrameAnalysis: text("key_frame_analysis"), // JSON from multi-frame vision analysis
   // Full AI analysis as JSON
   rawAnalysis: text("raw_analysis"), // full Claude response as JSON
   analyzedAt: text("analyzed_at").notNull().$defaultFn(() => new Date().toISOString())

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "better-sqlite3": "^12.8.0",
         "drizzle-orm": "^0.45.2",
         "next": "^14.2.0",
+        "openai": "^6.33.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "three": "^0.176.0"
@@ -5667,6 +5668,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.33.0.tgz",
+      "integrity": "sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "better-sqlite3": "^12.8.0",
     "drizzle-orm": "^0.45.2",
     "next": "^14.2.0",
+    "openai": "^6.33.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "three": "^0.176.0"


### PR DESCRIPTION
## Summary
- Downloads video posts, extracts audio with ffmpeg, transcribes with OpenAI Whisper
- Extracts 5 key frames per video, sends to Claude vision for analysis (appearance, location, poses, energy)
- Spoken hooks (first 15 words of transcript) stored for pattern analysis
- Full pipeline integrated into Insights page: Analyze Content → process videos → generate report
- Report now includes transcript data and key frame highlights for top/bottom posts

## New dependencies
- `openai` npm package (Whisper API)
- `ffmpeg` system dependency (video/audio processing)

## Test plan
- [x] Build passes
- [x] Migration applies cleanly
- [x] API routes compile

Closes #106, closes #107