### PR TITLE
fix(dev): bypass OrbStack proxy in caddy sidecar (#119)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,15 @@ services:
     environment:
       TS_AUTHKEY: ${TS_AUTHKEY:-}
       TS_HOSTNAME: ${TS_HOSTNAME:-maddiehq}
+      # Bypass OrbStack's HTTP proxy for tsnet → controlplane traffic.
+      # Without this, the proxy can re-emit the registration CONNECT and
+      # tsnet creates a duplicate device (one canonical + one `-N` orphan).
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      NO_PROXY: "*"
+      http_proxy: ""
+      https_proxy: ""
+      no_proxy: "*"
     volumes:
       - ./tailscale/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_state:/config


### PR DESCRIPTION
Closes #119.

## What

Adds proxy-bypass env vars to the `caddy-dev` service in `docker-compose.yml` so tsnet talks directly to `controlplane.tailscale.com` instead of going through OrbStack's auto-injected HTTP proxy.

## Why

Without this, every cold start of the sidecar registers two devices on the tailnet — `maddiehq` plus `maddiehq-1` orphan. Over time the orphans accumulate as offline ghosts and DNS often resolves the working URL to the dead one.

## Test

```bash
docker compose down
docker volume rm maddiehq_caddy_state
docker compose up -d caddy-dev
```

Verify exactly one `maddiehq` device on tailnet, no `-1` orphan, and sidecar logs free of `tshttpproxy: using proxy` lines.

## Notes

Same fix as appseed#319, thrive#246, sprintbook (in PR #60), and parallel PR in moxmo.