### PR TITLE
docs(strategy): features-brainstorm memo for creator / OF funnel

### DIFF
--- a/docs/strategy/features-brainstorm.md
+++ b/docs/strategy/features-brainstorm.md
@@ -1,0 +1,293 @@
+# MaddieHQ — Features Brainstorm
+
+**Date:** 2026-05-13
+**Status:** Working strategy document. Opinionated. Not implemented unless tracked in a GH issue.
+**Target audience:** Influencers / content creators, with a sharp lens on **OnlyFans-funnel creators** who use Instagram as a top-of-funnel for paid OF subscriptions.
+**Today's MaddieHQ:** Instagram OAuth + sync; per-post analytics (reach / impressions / saves / shares / likes / comments); audience demographics; AI image + caption analysis (Claude); video transcription (Whisper) + 5-frame key-frame analysis (Claude vision); pattern detection + pattern deep-dives.
+
+---
+
+## Executive summary
+
+1. **The IG-analytics-tool market is a commodity** (Hootsuite, Vista Social, Later, Predis.ai). MaddieHQ is *already* differentiated against them because we cross-reference visual + caption + engagement at the post level, not as separate dashboards.
+2. **The real money is in the OF segment.** OF agencies pay $40–$60/creator/month for Infloww / Supercreator / Creator Hero just for chat CRM + mass DM. Top creators bring in 60%+ of revenue from PPV — that's an entirely separate workflow no IG analytics tool touches. ([Infloww pricing](https://infloww.com/onlyfans-crm-enterprise), [influencermarketinghub.com](https://influencermarketinghub.com/onlyfans-monetization/))
+3. **The flywheel we should own:** *Instagram reach → DM intent capture → OF subscription → PPV value-ladder.* Today every tool covers exactly one of these stages. Whoever covers the joins owns the creator.
+4. **MaddieHQ's unfair advantage is the visual+language+performance triangulation we already do.** Extending that to (a) predict *next-post* performance, (b) auto-draft the next reel concept, and (c) write the DM/PPV copy that mirrors the creator's voice would beat every adjacent tool on insight depth.
+5. **AI video generation is hitting "good enough"** for B-roll, faceless content, and even creator avatar dubbing (Veo 3.1, Pika 2.5, ElevenLabs voice clones), but **OF's 2026 policy update bans deepfakes** and requires `#AI`/`#AIGenerated` disclosure on any AI content depicting the creator. ([OF AI policy](https://list25.com/onlyfans-2026-policy-updates-ai-deepfake-ban-verification/), [sirency.com](https://www.sirency.com/blog/onlyfans-policy-updates-2026-ai-deepfakes-and-compliance-rules)) Generative video features need to be designed around this — own-likeness, verified, labeled.
+6. **Comment-to-DM is the single biggest growth lever on Instagram for OF creators.** ManyChat, Inro, Creatorflow already do this; the conversion-rate uplift over manual is 25–40% → 8–15% baseline. ([creatorflow.so](https://creatorflow.so/blog/instagram-dm-automation-tools-comparison-2026/)) MaddieHQ should ship comment-to-DM with **voice-mirrored copy** powered by RAG over the creator's caption history — neither side currently combines those.
+7. **Vault management is the unspoken bottleneck.** OF agencies waste tens of thousands per month on it. ([ofauditor.app](https://ofauditor.app/blog/vault-management.html)) MaddieHQ can index the same key-frame metadata it already extracts for IG into a unified content vault that recommends *which* old PPV to resend to *which* fan segment.
+8. **Platform-policy and rate-limit constraints define what we can ship:** Instagram Graph API is 200 calls/account/hour; `instagram_manage_insights` only returns demographics for the authed account owner; cold DMs are forbidden — only response to user-initiated interaction. ([creatorflow.so rate limits](https://creatorflow.so/blog/instagram-api-rate-limits-explained/), [getphyllo.com](https://www.getphyllo.com/post/instagram-api-integration-101-for-developers-of-the-creator-economy)) Don't build anything that needs to break these.
+9. **The three differentiators I'd commit to:** (a) **closed-loop optimization** — every recommendation we make is measured against the post that ships from it; (b) **creator-voice fidelity** — every piece of generated copy is auto-graded against the creator's caption corpus before being shown; (c) **funnel-aware analytics** — every IG metric is annotated with downstream OF conversion signal where we can get it.
+10. **Don't try to be Infloww.** Building an OF chat-CRM means scraping OnlyFans' web UI (ToS-grey), running mass-DM agents (risky), and competing with established players. *Sit one layer above them:* be the intelligence layer they all integrate with via API.
+
+---
+
+## 1 — Competitive landscape
+
+This isn't exhaustive; it's the bands MaddieHQ needs to know cold. Pricing is creator-tier where available; agency tiers are noted separately.
+
+### 1.1 OnlyFans-native CRMs and chat tools
+
+| Tool | What it actually does | Pricing | Differentiator | Gap MaddieHQ can exploit |
+|---|---|---|---|---|
+| **Infloww** | OnlyFans CRM: unified inbox (40% faster chat), Smart Lists subscriber segmentation, Vault Pro content organization, mass DM, auto-messaging, sensitive-word blocker, per-creator dedicated IPs | $40/creator/mo OF, $50/mo Fansly; <$500 earners only at base tier ([infloww](https://infloww.com/onlyfans-crm-enterprise)) | "Agency-grade" — ops focus, not creator focus | Zero IG-side intelligence. No "what to send next" — only "send it faster." |
+| **Supercreator** | OnlyFans CRM + **Izzy** (AI chatter), unified inbox, mass DM, vault, analytics | Paid (creator + agency tiers); freemium for the AI video app side ([supercreator.app](https://www.supercreator.app/pricing)) | Strongest AI-chatter in the space (response generation, follow-ups, "creator stays in control") | The chatter doesn't know the *fan*'s relationship to the *creator's* IG presence. We can supply that signal. |
+| **CreatorHero** | OF CRM, vault, scheduling, lighter analytics | Creator pricing (paid) ([creatorhero](https://www.creatorhero.com/)) | Cleaner UX than Infloww | Same gap as Infloww — no IG layer. |
+| **OnlyMonster** | Desktop browser-based OF management tool, AI assistant | Paid creator/agency ([onlymonster.ai](https://onlymonster.ai/)) | Browser-extension model = faster install | Limited analytics depth. |
+| **Sozee** | OnlyFans content automation, scheduling, agency comparison content | Agency tier ([sozee.ai](https://sozee.ai/resources/best-onlyfans-management-software-2026/)) | Heavy SEO presence | Content thin; no proprietary AI loop. |
+
+### 1.2 Mainstream IG analytics / scheduling
+
+| Tool | Offering | Pricing | Why creators leave | MaddieHQ angle |
+|---|---|---|---|---|
+| **Hootsuite** | Enterprise scheduling, analytics, social listening, ad mgmt, CRM integrations | $99+/mo ([capterra](https://www.capterra.com/compare/121701-239366/HootSuite-vs-Vista-Social)) | Built for teams, not creators. Expensive, complex. | Wrong audience entirely. |
+| **Vista Social** | 13+ network scheduling, unified inbox, analytics across 5 categories, competitor analysis, review mgmt | Lower mid-range; analytics in all tiers ([vistasocial](https://vistasocial.com/insights/vista-social-vs-hootsuite/)) | Solid breadth, shallow depth on any one platform | We go deeper on IG visual analysis than they ever will. |
+| **Later** | Visual planner, IG-centric, link-in-bio (Linkin.bio) | Free + paid tiers | IG depth is decent, but no AI pattern detection | We do AI patterns. They don't. |
+| **Predis.ai** | AI content creation (posts, carousels, video ads), scheduling, hashtag generation | $27+/mo, free trial ([predis.ai](https://predis.ai/pricing/)) | Generative-first, analytics-second | Predis generates *ad creative* — we analyze *what already worked*. Reverse polarity. |
+
+### 1.3 Short-form video tooling
+
+| Tool | What | Pricing | Strength | Weakness |
+|---|---|---|---|---|
+| **OpusClip** | Long video → viral clips with virality score 1–100, AI B-roll, scheduling | Free / $15 / $29 / custom ([opusclip](https://www.opus.pro/pricing)) | "ClipAnything" + virality score, $215M valuation; 172M clips generated, 10M users ([opus.pro](https://www.opus.pro/)) | One-shot tool. No memory of what worked on *your* account. |
+| **Captions** | AI video editing: auto-captions, eye-contact correction, AI Twins/actors, dubbing in 28+ languages w/ lip-sync | Free / $9.99 / $24.99 / $69.99 ([captions.ai](https://captions.ai/pricing)) | Mobile-first, polished UX, AI Twins are unique | Credits make pricing unpredictable. Not OF-aware. |
+| **Crayo AI** | Text → faceless short videos (Reddit-story, fake-text, split-screen templates), 50+ voices | $13–$79/mo ([crayo.ai](https://crayo.ai/blog/can-ai-create-videos)) | Template-driven viral workflows | Faceless niche; not for personal-brand creators. |
+| **Supercreator AI Video** | (separate product) Topic → script → voiceover → video, mobile, 3-min avg, 10 videos/wk for active users | Freemium ([supercreator.ai](https://www.supercreator.ai/more-info)) | Mobile-first | Confusable brand with the OF CRM side. |
+
+### 1.4 Link-in-bio for OF creators
+
+| Tool | Strength | Pricing | OF-friendly? |
+|---|---|---|---|
+| **Linktree** | Standard | Free + paid | **NO — bans adult content** ([theleap](https://www.theleap.co/blog/beacons-vs-snipfeed/)) |
+| **Beacons** | Email capture, digital store, analytics, media kit | Free / $10 / $30 ([sirency](https://www.sirency.com/blog/best-link-in-bio-tools-onlyfans-2026)) | Yes |
+| **Snipfeed** | Sells livestreams, memberships, video calls; no free plan | $9 (10% fee) / $20 (0%) | Yes |
+| **AllMyLinks** | OF-friendly, simple | Free + paid | Yes |
+
+### 1.5 DM automation
+
+| Tool | What | Pricing | Limit |
+|---|---|---|---|
+| **ManyChat** | Comment-to-DM, story-reply-to-DM, follow-to-DM; flow builder | Free / $14 / $15+ ([manychat](https://manychat.com/product/instagram)) | Cannot cold-DM (Instagram API restriction). No voice mirroring. |
+| **Inro** | OF-aware DM automation guidance + tooling | ([inro.social](https://www.inro.social/blog/best-automation-tools-for-onlyfans-creators-in-2025)) | Smaller; less mature flow builder than ManyChat. |
+
+### 1.6 What's missing in the market
+
+Reading across all of this: **nobody owns the join between IG signal and OF revenue.** Infloww knows your top PPV buyers but not which IG post drove them in. ManyChat fires the DM but doesn't write copy in your voice. Captions makes a beautiful clip but doesn't know it'll bomb on *your* audience. **MaddieHQ has the right substrate (post-level visual+caption+performance) to be the brain that sits above all of them.**
+
+---
+
+## 2 — Cutting-edge AI feature ideas
+
+Grouped by **the goal it serves**, not by AI primitive. For each: what it does, the AI primitive, why a creator pays, and the closest existing competitor (always weaker than what we'd ship). 25 ideas total.
+
+### 2.1 Growth — get more reach and followers
+
+1. **Next-Post Predictor.** Before the creator publishes, drag in the draft image + caption — we return a predicted reach band (P25/P50/P75) based on a regression over the creator's own post-analysis joined to post-insights, with a bullet list of "this resembles posts that scored X in saves; tweak Y for +20%". *Primitive:* RAG + lightweight gradient-boosted model over per-creator embeddings of `(visual_attrs, caption_attrs, time_of_day)` → engagement. *Why pay:* every creator wants this; nobody offers it because nobody has the joined dataset. *Competitor:* OpusClip's virality score (account-agnostic; ours is creator-specific).
+2. **Top-Performer Cloner.** "Show me 5 reels concepts that lean into the patterns your top-decile posts share." Outputs storyboards: opening frame description, B-roll beats, suggested spoken hook, suggested caption, suggested CTA. *Primitive:* Claude vision over creator's top-N key-frame analyses + caption embeddings + few-shot Claude prompt. *Why pay:* creator's block is "what do I post next" — we hand them five tested concepts. *Competitor:* none; Predis generates *generic* content, OpusClip clips *existing* content.
+3. **Comment-to-DM with voice-mirrored copy.** Detect IG comments matching keyword triggers ("link", "where", "OF"), reply publicly with neutral language, send DM with copy that's *graded against the creator's caption-tone embedding* so it sounds like them, not a bot. *Primitive:* IG webhook + RAG over creator's caption corpus + Claude generation with style-grading rubric. *Why pay:* ManyChat does the firing; we do the *writing*. *Competitor:* ManyChat (no voice mirroring), Inro (lighter).
+4. **Story-Reply-to-OF-Funnel.** Same machinery applied to story replies — the highest-intent IG signal. Auto-segment repliers (sticker-tap vs message vs share) and route accordingly. *Primitive:* IG Stories webhooks + state machine + Claude copy generation. *Why pay:* sticker-tap repliers are the warmest leads in the IG flywheel; nobody segments by reply type.
+5. **Shadowban early-warning.** Auto-monitor reach delta on tagged hashtags and on baseline posts; alert when reach drops >2 sigma. ([Shadowban detection tools](https://www.tameyogroup.com/instagram-shadow-ban-check)) *Primitive:* simple per-creator anomaly detection; surface in a daily digest. *Why pay:* shadowbans are silent revenue death; existing tools charge $97 for one audit ([tameyogroup](https://www.tameyogroup.com/instagram-shadow-ban-check)) — we ship it as a side-effect of having the data.
+6. **Hashtag and caption A/B optimizer.** Given a draft post, generate 3 alternate captions + 3 alternate hashtag sets, rank by predicted reach, and run a real A/B on the next two posts via re-publishing window if engagement underperforms. *Primitive:* Claude + per-creator engagement model. *Competitor:* IQ Hashtags (generates hashtags blindly).
+
+### 2.2 Production efficiency — make more, faster
+
+7. **AI-drafted reel concept** (subsumes #2 above as a recurring loop). Weekly digest: "5 reels to shoot this week, ranked by predicted save-rate. Here's the shot list + spoken hook + caption + audio track." *Primitive:* Same as #2 + trending-audio scraping (Apify-grade). *Why pay:* creator-block elimination. *Competitor:* none we found.
+8. **Key-frame to storyboard.** Click any top-performing reel, get an editable storyboard reproducing its visual rhythm: shot 1 setting/lighting/pose, shot 2, etc. *Primitive:* Already have `key_frame_analysis_json` per video. Just expose it as a UI affordance. *Why pay:* "I want to remix my own best reel." *Competitor:* none.
+9. **AI B-roll, on-brand.** Generate B-roll clips that match a creator's color palette and visual style using Veo 3.1's reference-image feature (4 ref images per gen). ([Veo 3.1 ingredients-to-video](https://pxz.ai/blog/veo-31-vs-top-ai-video-generators-2026)) *Primitive:* Veo 3.1 API + creator's top-frame palette. *Why pay:* faster reel finishes. *Competitor:* OpusClip's AI B-roll is generic; ours is style-matched.
+10. **Caption + spoken-hook co-writer.** Side-by-side editor: type the caption, it generates 3 matching spoken hooks (transcribed-style) for the reel voiceover, OR transcribe the spoken hook from a draft and generate the caption that converts viewers from it. *Primitive:* Whisper + Claude. *Why pay:* tightening the caption-to-hook coherence is the single biggest underutilized lever.
+11. **Voice-cloned dub for repurposing.** Take a top-performing reel, dub in 28+ languages via ElevenLabs ([elevenlabs](https://elevenlabs.io/voice-cloning)), preserve creator voice; recommend which markets to ship to based on demographics. *Primitive:* ElevenLabs API + creator demographic targeting. *Why pay:* one viral reel → 5 markets without re-shooting. *Competitor:* Captions does dubbing but doesn't recommend markets.
+12. **Auto-clip from livestreams or long-form.** Same as OpusClip but trained on the creator's own engagement signal — pick clips that match the moments that historically drove saves. *Primitive:* whisper transcripts + per-creator save-density model. *Why pay:* most creators don't go live because they don't know how to chop it.
+13. **One-tap content recycler.** For each "evergreen" post (defined as: top-25%-saves, posted ≥90 days ago, ≤10% follower overlap with current followers), generate a "remix" variant — same shot framing, new caption + new opening line — to repost. *Primitive:* MaddieHQ analysis library + Claude.
+
+### 2.3 Conversion — IG follower → OF subscriber
+
+14. **Funnel attribution.** A creator pastes their `linkin.bio` (Beacons / AllMyLinks) link; we set up click tracking (UTM-based) and join IG post performance → bio-click → OF subscriber where possible. We can't auto-pull OF directly (no public API) but we can pull aggregate creator-reported numbers via webhook from Infloww/Supercreator + manual entry. *Primitive:* link-tracker microservice + creator-side webhook intake. *Why pay:* nobody can tell creators which IG post sold the most OF subs; we can. *Competitor:* nothing public.
+15. **Audience tagger.** Cluster IG followers by inferred-from-bio signals (location, lifestyle keywords) into segments; export segments to ManyChat/Beacons for differential DM/landing. *Primitive:* sentence-transformers over public follower bios (must respect rate limits + ToS). *Why pay:* a lifestyle-creator audience and an OF-niche audience need different funnels; today they get the same one.
+16. **Hot-fan radar.** Detect IG followers exhibiting OF-buyer intent signals (rapid follow + DM/save/share within first 48h after follow) and surface a daily "warm leads" list that DM automation can prioritize. *Primitive:* state-machine over IG webhooks. *Why pay:* concentrates DM bandwidth on the fans most likely to convert. *Competitor:* none.
+
+### 2.4 Monetization — increase PPV revenue once subscribed (Pro tier ladder into OF agency space)
+
+17. **Vault recommender.** For a given fan (passed in via Infloww/Supercreator integration), recommend the next PPV from the creator's vault based on fan's purchase history + content tags + (where surfaced) fan engagement signals. *Primitive:* embedding-based recommender over vault content + fan purchase history. *Why pay:* OF top-creator PPV is 60%+ of revenue ([influencermarketinghub](https://influencermarketinghub.com/onlyfans-monetization/)); even a 5% lift is enormous. *Competitor:* Infloww has Smart Lists but no recommender.
+18. **PPV price suggester.** Per-fan, suggest the optimal PPV price based on past purchases, time since last PPV, fan LTV cohort. *Primitive:* per-creator regression. *Why pay:* underpricing leaves money on the table; overpricing kills conversion. *Competitor:* none.
+19. **Welcome-message DM in creator voice.** When OF reports a new subscriber via webhook, fire a welcome DM crafted from the creator's caption-voice corpus + first-PPV pitch. *Primitive:* Claude + RAG. *Why pay:* the first-48-hour PPV is the highest-value moment ([ofauditor](https://ofauditor.app/blog/vault-management.html)); automating it without sounding bot-y is gold. *Competitor:* Infloww auto-messaging exists; ours is voice-matched.
+20. **Renewal-risk alerter.** OF subscriber inactive ≥14 days → suggest a "re-engagement" PPV from the vault, drafted in creator voice. *Primitive:* idle-detection + Claude. *Why pay:* churn is the silent killer in OF revenue. *Competitor:* none with content-aware re-engagement.
+
+### 2.5 Audience intelligence
+
+21. **Audience-to-content fit score.** Each post is graded against the demographic mix of the creator's audience: "your audience is 60% 18–24 women, this post leans 35–44 male audiences — expect lower reach." *Primitive:* embeddings over audience cluster vs post-visual cluster. *Why pay:* explains underperformance proactively. *Competitor:* none.
+22. **Competitor pattern reverse-engineering.** Creator pastes 3 competitor IG handles; we (within IG's API constraints, public-content-only) analyze their public-feed posts and identify patterns *they* are using that the creator isn't. *Primitive:* IG Business Discovery API + same analysis pipeline applied to non-auth'd accounts. ([Phyllo](https://www.getphyllo.com/post/instagram-api-integration-101-for-developers-of-the-creator-economy)) *Why pay:* "what is my competitor doing right" is the universal question; nobody answers it with vision-level analysis.
+23. **Trend-aware reel concept.** Cross-reference the creator's top-pattern templates with currently-trending audio + visual motifs (scraped from TikTok/Reels trending). *Primitive:* trends scrape + Claude pattern-matcher. *Why pay:* "ride the trend in *your* style". *Competitor:* none integrating trend awareness with creator-specific style.
+24. **Time-of-week heatmap with cohort weighting.** Not "post at 7pm" — post at "the time your top-decile-engagement cohort is on" weighted by follower active hours. *Primitive:* IG insights snapshots. *Why pay:* concrete, defensible posting cadence.
+25. **Pattern explainer in plain English.** Already exists in MaddieHQ (the elaborate endpoint). Lean into it harder: surface elaborations on the daily/weekly digest, not just on click. *Primitive:* Claude. *Why pay:* the difference between "data" and "advice."
+
+---
+
+## 3 — OF-specific growth mechanics
+
+The IG → OF flywheel is the single largest creator-economy revenue engine on the planet ([influencermarketinghub](https://influencermarketinghub.com/onlyfans-monetization/)) and it's structurally underserved by tooling. Stages:
+
+1. **Top of funnel — IG reach.** Creator posts; the algorithm decides who sees it. The IG-side levers are visual quality, caption hook, hashtag use, posting cadence, video watch-time. MaddieHQ already analyzes all of these.
+2. **Intent capture — DM / Story reply / saved post.** Highest-intent signal on IG is a story reply, then a DM, then a save, then a share, then a like. MaddieHQ today does not surface intent signals; it should.
+3. **Off-platform redirect — link-in-bio.** A bio link aggregator (Beacons, AllMyLinks — never Linktree for adult creators ([theleap](https://www.theleap.co/blog/beacons-vs-snipfeed/))). UTM tracking is critical here.
+4. **OF subscription decision.** Free preview content, price anchoring, "free month" promo are the main levers; the creator-facing tooling is split between OF native and the CRMs.
+5. **PPV value-ladder.** Welcome message + first PPV in 48h is the canonical pattern ([thewebaddicted](https://thewebaddicted.com/blog/onlyfans-ppv-explained/)). Top creators do hybrid: ~55% of posts on the wall, rest gated as PPV ([pseudoface](https://www.pseudoface.com/guides/start-here/profile-setup/onlyfans-wall-vs-ppv-value-ladder)).
+6. **Retention — re-engagement, custom content, vault recycling.** OF vault management is the unspoken bottleneck — top operators tag content by type/mood/length/season and recycle ([ofauditor](https://ofauditor.app/blog/vault-management.html)).
+
+### What MaddieHQ can uniquely do across stages
+
+- **Cross-stage attribution** — connect "IG post X drove 47 bio-link clicks → 12 OF subs → $340 in first-48h PPV." No other tool has this view because none span IG + bio-link + OF.
+- **Tag the vault using the same metadata we already extract for IG analysis.** Setting / lighting / face / energy / pose / scene-change — the OF vault and IG post DB share the same schema. A creator's "post-OF-shoot" content stream becomes searchable, recommendable, and recyclable using infrastructure we already have.
+- **Predict which IG post will drive OF subs**, not just reach. Once we have funnel attribution data, the next-post predictor can optimize for *OF conversion* instead of just engagement.
+- **Train the comment-to-DM and welcome-DM models on the creator's caption corpus**, so it sounds like them, not a Filipino chatter farm (which is genuinely the dominant model today and is itself being disrupted by AI — see [Rest of World](https://restofworld.org/2025/onlyfans-ai-dm-bots/)).
+
+### Constraints honest about
+
+- **No OF public API.** Everything OF-side has to be either (a) creator-self-reported, (b) webhook from a partnered CRM (Infloww/Supercreator may or may not open up), or (c) browser extension. Build the integration layer assuming (a)+(c) at first.
+- **OF AI policy** ([sirency](https://www.sirency.com/blog/onlyfans-policy-updates-2026-ai-deepfakes-and-compliance-rules)): AI content depicting the creator must be tagged `#AI`/`#AIGenerated`; deepfakes of *real* people (other than the verified creator's own likeness) are immediate-ban. Build feature gates that enforce these labels.
+- **IG API can't cold-DM.** Comment-to-DM and story-reply-to-DM are allowed because they respond to user-initiated interaction ([creatorflow](https://creatorflow.so/blog/instagram-dm-automation-tools-comparison-2026/)). Cold-DM strategies are off-limits.
+
+---
+
+## 4 — Differentiation strategy
+
+Of all the features above, **pick a small number and commit hard.** I'd choose 4:
+
+### 4.1 "We close the loop"
+
+Every recommendation MaddieHQ makes (next-post predictor, hashtag A/B, top-performer cloner, vault recommender) is **tracked back to the post or DM that ships from it.** A creator's dashboard shows "we suggested X, you shipped Y, here's what happened." That measurement loop is the foundation of every other moat.
+
+**Tradeoff:** Slower feature shipping; every recommendation needs an outcome-tracking schema. **Worth it:** it's the only way to credibly beat OpusClip's per-clip virality score with per-creator virality score.
+
+### 4.2 "Voice fidelity, always"
+
+Every piece of AI-generated copy (DMs, captions, hooks, welcome messages, PPV pitches) is scored against an embedding of the creator's existing caption corpus. If the score falls below a threshold, we surface the warning and let the creator edit. Nobody in the space does this — Infloww and Supercreator's AI chatters use generic prompts; ManyChat doesn't generate at all.
+
+**Tradeoff:** Setup needs ≥30 captions of corpus. **Worth it:** "AI that sounds like me" is the single most-requested feature in creator-economy research and the easiest tagline to sell.
+
+### 4.3 "Funnel-aware analytics"
+
+We don't just analyze IG. We give creators a single funnel view from reel → bio-link → subscription → PPV revenue, and every IG-side metric is annotated with downstream OF impact where we have data. Other IG tools stop at "engagement"; OF tools start at "subscriber." We span the gap.
+
+**Tradeoff:** Requires creator to wire up Beacons/AllMyLinks + ideally an Infloww webhook. Hard to make zero-config. **Worth it:** no competitor spans this gap. None.
+
+### 4.4 "Intelligence layer, not chat tool"
+
+Be the brain Infloww/Supercreator/ManyChat plug into via API. Don't build a competing OF chat CRM (high cost, regulatory grey area, sticky users at competitors). Sell creator agencies an analytics + recommendation layer that *sends data into* their existing tools.
+
+**Tradeoff:** Smaller TAM than building the whole stack. **Worth it:** dramatically faster GTM, lower compliance surface, integration-led growth.
+
+### Anti-differentiators (things we should NOT do)
+
+- **Don't build the chat-CRM itself.** Infloww raised money for that; it's a knife-fight. Sit one layer up.
+- **Don't generate AI nude/adult content.** OF 2026 policy effectively bans the third-party-AI-of-creator workflow without strict verification ([sirency](https://www.sirency.com/blog/onlyfans-policy-updates-2026-ai-deepfakes-and-compliance-rules)); the legal/PR risk of getting it slightly wrong is existential.
+- **Don't run cold-DM bots.** Against IG ToS; ban-risk is total ([icekulfi](https://www.icekulfi.com/blogs/instagram-automation-policies-guide)).
+- **Don't try to deep-link Linktree for OF creators.** They ban adult content.
+
+---
+
+## 5 — Compliance and ToS landmines
+
+The platforms in this stack have heavy 2026 policy enforcement. Build features inside these lines.
+
+### 5.1 Instagram / Meta
+
+- **Cold DMs forbidden.** The IG API only allows DMs that respond to user-initiated interaction (comment, story reply, prior DM). Comment-to-DM is fine; cold-DM bots get the developer app banned ([creatorflow](https://creatorflow.so/blog/instagram-dm-automation-tools-comparison-2026/)).
+- **Rate limits:** 200 API calls per IG account per rolling hour ([creatorflow rate limits](https://creatorflow.so/blog/instagram-api-rate-limits-explained/)). Batch + cache aggressively.
+- **`instagram_manage_insights` scope** only returns demographic data for the authed account itself — we cannot fetch demographics for any account that hasn't authed us ([Phyllo](https://www.getphyllo.com/post/instagram-api-integration-101-for-developers-of-the-creator-economy)). Plan UX around per-account OAuth.
+- **OnlyFans link in bio is technically allowed but flag-prone.** ([phoenix-creators](https://www.phoenix-creators.com/onlyfans-blog/can-you-post-onlyfans-link-on-instagram), [enforcity](https://www.enforcity.com/onlyfans-success/promoting-onlyfans-on-instagram)) Recommend Beacons / AllMyLinks (which are adult-friendly) over direct linking. Linktree bans adult content outright.
+- **Adult content in captions or hashtags triggers reduced reach** (shadowban) even without explicit imagery ([phoenix-creators](https://www.phoenix-creators.com/onlyfans-blog/can-you-post-onlyfans-link-on-instagram)). Shadowban warning feature is a natural fit (#5 in features).
+- **2026 teen-safety push:** Meta is restricting recommendation surfaces for accounts flagged as age-inappropriate ([about.fb.com](https://about.fb.com/news/2026/04/instagram-expands-teen-accounts-inspired-by-13-content-ratings/)). Adult-adjacent creators face increasing reach throttling. Our shadowban/reach-anomaly detection should explicitly call out posts that may have triggered teen-content filters.
+
+### 5.2 OnlyFans (2026 update)
+
+- **Deepfakes of real people = permanent ban** ([list25](https://list25.com/onlyfans-2026-policy-updates-ai-deepfake-ban-verification/)).
+- **AI content depicting the creator** must be labeled `#AI` or `#AIGenerated` ([sirency](https://www.sirency.com/blog/onlyfans-policy-updates-2026-ai-deepfakes-and-compliance-rules)). Build this into our caption generator as a hard-coded prefix on any AI-image-driven post.
+- **AI enhancement of real creator content is OK** — sharpen, lighting, smoothing, dubbing in own-voice — as long as it's the creator's verified likeness.
+- **Geo-compliance + age-verification tightening** is rolling out in 2026 ([list25](https://list25.com/onlyfans-2026-policy-updates-ai-deepfake-ban-verification/)). Out of scope for MaddieHQ; just don't make features that complicate it.
+
+### 5.3 ElevenLabs / voice cloning
+
+- ElevenLabs **Professional Voice Clone** requires consent and is intended for the speaker's own voice ([elevenlabs voice cloning](https://elevenlabs.io/docs/eleven-creative/voices/voice-cloning)). For the welcome-DM / dubbing features we'd require the creator to PVC their own voice — clean compliance.
+- **Don't enable voice clones of fans, agents, or anyone other than the verified creator.** Liability and policy risk too high.
+
+### 5.4 Internal compliance affordances
+
+- Every AI-generated artifact (caption, DM, frame, dub) should be **tagged in our DB** with `generated_by_ai=true` so we can support future audit requirements.
+- The Voice Fidelity gate doubles as a safety gate — anything generated must pass a tone match against the creator's own corpus before being eligible to send. This effectively prevents the system from being weaponized to impersonate someone else (the corpus *is* the creator's identity).
+- **Per-creator data isolation** is already enforced at the schema level (Phase 1 of the AI epic) — don't regress this. Every new feature inherits the `user_id`-scoped pattern.
+
+---
+
+## What to ship next (opinionated)
+
+If I had to pick three features from this memo to put in the next two milestones:
+
+1. **Next-Post Predictor (feature #1)** — leverages existing data, no new integration surface, immediately useful, demonstrably differentiated, sells the product on its own.
+2. **Comment-to-DM with voice-mirrored copy (feature #3)** — bridges IG → OF in the most concrete way possible, plugs into the IG webhook surface, requires the caption-corpus embedding which sets up Voice Fidelity (#4.2) as a reusable substrate.
+3. **Funnel attribution (feature #14)** — even at v1 (creator pastes UTM-tagged Beacons link, we track click-through), proves the "we close the loop" thesis (#4.1) and unlocks every downstream feature that needs OF-side signal.
+
+Skip the chat-CRM and the AI video generation for now. Sit one layer above.
+
+---
+
+## Sources
+
+- [Infloww — OnlyFans CRM Enterprise](https://infloww.com/onlyfans-crm-enterprise)
+- [Supercreator — Pricing](https://www.supercreator.app/pricing)
+- [Supercreator AI Chatter (Izzy)](https://www.supercreator.app/ai-chatter)
+- [CreatorHero](https://www.creatorhero.com/)
+- [OnlyMonster](https://onlymonster.ai/)
+- [Sozee — Best OnlyFans management software 2026](https://sozee.ai/resources/best-onlyfans-management-software-2026/)
+- [Boese VA — Top OnlyFans Management Software 2026](https://www.boese-va.com/blog/onlyfans-management-software-comparison)
+- [NimbusReach — Infloww vs Supercreator](https://blog.nimbusreach.io/onlyfans-crm-tools-comparison-infloww-supercreator/)
+- [Capterra — Hootsuite vs Vista Social](https://www.capterra.com/compare/121701-239366/HootSuite-vs-Vista-Social)
+- [Vista Social vs Hootsuite](https://vistasocial.com/insights/vista-social-vs-hootsuite/)
+- [Vista Social vs Later](https://vistasocial.com/insights/vista-social-vs-later)
+- [Predis.ai — Pricing](https://predis.ai/pricing/)
+- [Predis.ai — Capterra](https://www.capterra.com/p/231932/Predisai/)
+- [OpusClip — Pricing](https://www.opus.pro/pricing)
+- [OpusClip — Homepage](https://www.opus.pro/)
+- [OpusClip Review (CheckThat.ai)](https://checkthat.ai/brands/opusclip/pricing)
+- [Captions AI — Pricing](https://captions.ai/pricing)
+- [Captions AI — Subscriptions & Plans](https://captions.ai/help/docs/subscriptions)
+- [Crayo AI Review (AboutChromebooks)](https://www.aboutchromebooks.com/crayo-ai)
+- [Crayo AI](https://crayo.ai/blog/can-ai-create-videos)
+- [Supercreator AI Video](https://www.supercreator.ai/more-info)
+- [Beacons vs Snipfeed — TheLeap](https://www.theleap.co/blog/beacons-vs-snipfeed/)
+- [SirenCY — Best link-in-bio tools for OnlyFans 2026](https://www.sirency.com/blog/best-link-in-bio-tools-onlyfans-2026)
+- [Aruna Talent — OnlyFans link-in-bio tools](https://arunatalent.com/blog/onlyfans-link-in-bio-tools/)
+- [ManyChat — Instagram product](https://manychat.com/product/instagram)
+- [ManyChat — Auto-DM links from comments](https://help.manychat.com/hc/en-us/articles/16654065283100-Quick-Automation-Auto-DM-links-from-comments)
+- [CreatorFlow — Instagram DM Automation Tools 2026](https://creatorflow.so/blog/instagram-dm-automation-tools-comparison-2026/)
+- [CreatorFlow — Instagram API rate limits 2026](https://creatorflow.so/blog/instagram-api-rate-limits-explained/)
+- [Inro — Best automation tools for OnlyFans creators](https://www.inro.social/blog/best-automation-tools-for-onlyfans-creators-in-2025)
+- [Inro — Avoid Instagram bans (OnlyFans creators)](https://www.inro.social/blog/avoid-instagram-bans-onlyfans)
+- [Phyllo — Instagram API integration 2026](https://www.getphyllo.com/post/instagram-api-integration-101-for-developers-of-the-creator-economy)
+- [Phyllo — Instagram API rate limits and scaling 2026](https://www.getphyllo.com/post/instagram-api-rate-limits-explained----and-how-to-scale-beyond-them-2026)
+- [Meta Developers — Graph API rate limiting](https://developers.facebook.com/docs/graph-api/overview/rate-limiting/)
+- [Meta Developers — Instagram Platform overview](https://developers.facebook.com/docs/instagram-platform/overview/)
+- [Meta Transparency — Community Standards](https://transparency.meta.com/policies/community-standards)
+- [Meta Transparency — Age-appropriate content](https://transparency.meta.com/policies/age-appropriate-content/)
+- [About Meta — Instagram expands teen accounts 2026](https://about.fb.com/news/2026/04/instagram-expands-teen-accounts-inspired-by-13-content-ratings/)
+- [IceKulfi — Instagram automation rules 2026](https://www.icekulfi.com/blogs/instagram-automation-policies-guide)
+- [Phoenix Creators — Can you post OnlyFans link on Instagram?](https://www.phoenix-creators.com/onlyfans-blog/can-you-post-onlyfans-link-on-instagram)
+- [Enforcity — Promoting OnlyFans on Instagram](https://www.enforcity.com/onlyfans-success/promoting-onlyfans-on-instagram)
+- [List25 — OnlyFans 2026 AI deepfake ban](https://list25.com/onlyfans-2026-policy-updates-ai-deepfake-ban-verification/)
+- [SirenCY — OnlyFans policy updates 2026: AI & deepfake rules](https://www.sirency.com/blog/onlyfans-policy-updates-2026-ai-deepfakes-and-compliance-rules)
+- [Sozee — AI disclosure rules OnlyFans agency 2026](https://sozee.ai/resources/ai-disclosure-rules-onlyfans-agency/)
+- [TAMEYO — Instagram shadow ban audit](https://www.tameyogroup.com/instagram-shadow-ban-check)
+- [IG HERO — Instagram shadowban](https://www.ig-hero.com/us/instagram-shadowban-how-to-check-fix)
+- [Companion Link — Top Sora 2 alternatives 2026](https://www.companionlink.com/blog/2026/05/top-10-sora-2-alternatives-in-2026-the-best-ai-video-generators-for-every-creator/)
+- [PXZ — Veo 3.1 vs top AI video generators 2026](https://pxz.ai/blog/veo-31-vs-top-ai-video-generators-2026)
+- [Pixflow — Best AI video generator 2026](https://pixflow.net/blog/best-ai-video-generator/)
+- [ElevenLabs — Voice cloning overview](https://elevenlabs.io/docs/eleven-creative/voices/voice-cloning)
+- [ElevenLabs — Voice cloning](https://elevenlabs.io/voice-cloning)
+- [TechSifted — How to use ElevenLabs 2026](https://techsifted.com/guides/how-to-use-elevenlabs/)
+- [Influencer Marketing Hub — OnlyFans monetization](https://influencermarketinghub.com/onlyfans-monetization/)
+- [Influencer Marketing Hub — Full-funnel creator strategy](https://influencermarketinghub.com/full-funnel-creator-strategy/)
+- [Influencer Marketing Hub — Creator revenue by stage](https://influencermarketinghub.com/creator-revenue/)
+- [TheWebAddicted — OnlyFans PPV explained 2026](https://thewebaddicted.com/blog/onlyfans-ppv-explained/)
+- [Pseudoface — OnlyFans wall vs PPV value ladder](https://www.pseudoface.com/guides/start-here/profile-setup/onlyfans-wall-vs-ppv-value-ladder)
+- [OF Auditor — OnlyFans vault management guide](https://ofauditor.app/blog/vault-management.html)
+- [Rest of World — AI threatens jobs of OnlyFans DM agents](https://restofworld.org/2025/onlyfans-ai-dm-bots/)
+- [MarketingBlocks — 50+ viral hook templates 2026](https://www.marketingblocks.ai/50-viral-hook-templates-for-ads-reels-tiktok-or-captions-2026-frameworks-examples-ai-prompts-included/)


### PR DESCRIPTION
## Summary

Closes #141. Adds `docs/strategy/features-brainstorm.md` — a working strategy memo Mark asked for overnight while AFK.

QA: N/A — docs only.

## What's in the memo

- **Executive summary** (10 bullets) — the high-leverage thesis.
- **Competitive landscape** — Infloww, Supercreator, Creator Hero, OnlyMonster, Hootsuite, Vista Social, Later, Predis.ai, OpusClip, Captions, Crayo, Supercreator AI Video, Beacons, Snipfeed, AllMyLinks, ManyChat, Inro. What each offers, pricing tier, weakness/gap. Cited.
- **25 AI feature ideas** grouped by goal: growth (6) / production efficiency (7) / IG-to-OF conversion (3) / OF monetization (4) / audience intelligence (5). Each: what it does, AI primitive (Claude vision, Whisper, ElevenLabs PVC, Veo 3.1 reference-image, RAG over caption corpus, etc.), why a creator pays, closest competitor (always weaker).
- **OF flywheel mechanics** — the IG → bio-link → OF sub → PPV value-ladder. Stage-by-stage. What MaddieHQ can uniquely do because we span the gap none of the existing tools span.
- **Differentiation strategy** — 4 commitments (close the loop, voice fidelity, funnel-aware analytics, intelligence layer not chat tool) with tradeoffs argued.
- **Compliance landmines** — Meta cold-DM ban + 200 req/hr rate limit + insights-API scope limits; OnlyFans 2026 deepfake ban + `#AI` disclosure; ElevenLabs consent rules.
- **Recommendation: 3 features to ship next** (next-post predictor, comment-to-DM with voice mirroring, funnel attribution).

All factual claims about external products are cited inline; full source list at the bottom of the memo.

## Why this lives in the repo, not in a Notion / Google Doc

So a future agent (or Mark) can read it alongside the code and so it shows up in `gh issue` history. It's a working doc — edit freely.
