### PR TITLE
feat(coomander): agent infrastructure (#151)

### DIFF
--- a/node/.env.example
+++ b/node/.env.example
@@ -109,6 +109,13 @@ ADMIN_EMAILS=admin@example.com
 # Shared secret guarding POST /api/coomander/run (the cron target). Generate with
 # `openssl rand -hex 32`. Set as a wrangler secret in prod and in .env.local for dev.
 # COOMANDER_RUN_SECRET=
+# Secret Telegram echoes back on the inbound webhook (set as secret_token at
+# setWebhook). Generate with `openssl rand -hex 24`. Set as a wrangler secret in
+# prod; the /api/coomander/webhook route 503s until it is set.
+# MADDIE_TELEGRAM_WEBHOOK_SECRET=
+# Anthropic model for Coomander pings + inbound classification (optional;
+# defaults to claude-sonnet-4-6).
+# COOMANDER_AGENT_MODEL=claude-sonnet-4-6
 # Explicit opt-out for outbound Telegram (1/true to force OFF). Default is ENABLED
 # in ALL environments (the bot is MaddieHQ-dedicated). Do NOT set a forcing value
 # in .env.local — it bakes into the prod bundle (next-env.mjs). Leave unset.

--- a/node/.env.example
+++ b/node/.env.example
@@ -100,3 +100,24 @@ ADMIN_EMAILS=admin@example.com
 # INSTAGRAM_CLIENT_SECRET=
 # Optional override; defaults to {request_origin}/api/platforms/instagram/oauth/callback
 # INSTAGRAM_OAUTH_REDIRECT_URI=
+
+# ── Coomander — AI ops agent (#151) ─────────────────────────────────────────
+# Telegram bot token for @coomander_bot (BotFather). Kept out of git; set as a
+# wrangler secret in prod (`wrangler secret put MADDIE_TELEGRAM_BOT_TOKEN`) and
+# in .env.local for dev. Outbound Telegram (cron pings) requires this.
+# MADDIE_TELEGRAM_BOT_TOKEN=
+# Shared secret guarding POST /api/coomander/run (the cron target). Generate with
+# `openssl rand -hex 32`. Set as a wrangler secret in prod and in .env.local for dev.
+# COOMANDER_RUN_SECRET=
+# Explicit opt-out for outbound Telegram (1/true to force OFF). Default is ENABLED
+# in ALL environments (the bot is MaddieHQ-dedicated). Do NOT set a forcing value
+# in .env.local — it bakes into the prod bundle (next-env.mjs). Leave unset.
+# COOMANDER_TELEGRAM_DISABLED=
+
+# ── Remote dev over HTTPS — Tailscale + Caddy sidecar ───────────────────────
+# Required for phone QA (iOS Safari refuses plain HTTP on *.ts.net). Auth key
+# from https://login.tailscale.com/admin/settings/keys. Final URL:
+# https://${TS_HOSTNAME}.gate-cardassian.ts.net
+# TS_AUTHKEY=tskey-auth-...
+# TS_HOSTNAME=maddiehq
+# DEV_PORT=3005

--- a/node/app/api/coomander/run/route.ts
+++ b/node/app/api/coomander/run/route.ts
@@ -1,0 +1,98 @@
+/**
+ * POST /api/coomander/run — Coomander cron entrypoint (#151, milestone 1).
+ *
+ * Fired by the Cloudflare cron (see custom-worker.ts), not a browser, so there
+ * is no user session. Guarded by a shared secret: the caller must send
+ * `x-agent-secret: $COOMANDER_RUN_SECRET`. Returns 503 if the secret is unset,
+ * 401 on mismatch. Always returns 200 with a status object on the happy path so
+ * the cron never sees a 500 and retry-storms.
+ *
+ * MILESTONE 1 SCOPE (deliberately minimal — see docs/strategy/next-session-brief.md §6):
+ *   - No planPing decision logic yet: the ping is UNCONDITIONAL (good for testing).
+ *   - No slot routing: the request body's `slot` is accepted but ignored.
+ *   - Iterate every user with `coomanderEnabled = 1` AND a `telegramChatId`,
+ *     send a fixed placeholder message, and log each send to
+ *     `coomander_message_log` (the indefinite-retention substrate).
+ *
+ * Decision logic, per-slot persona prompts, and nag presets land in later
+ * milestones.
+ */
+
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { getDb } from "@/lib/db";
+import { user, coomanderMessageLog } from "@/lib/schema";
+import { sendTelegram } from "@/lib/coomander/telegram";
+import { log } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// PLACEHOLDER — real persona-driven content lands in #153. This fixed string
+// only proves the cron → route → Telegram → log path end-to-end.
+const PLACEHOLDER_MESSAGE = "Coomander online — this is a test ping. The infra works.";
+
+export async function POST(request: Request) {
+  const secret = process.env.COOMANDER_RUN_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "COOMANDER_RUN_SECRET not configured" }, { status: 503 });
+  }
+  if (request.headers.get("x-agent-secret") !== secret) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  // Body is optional; `slot` is accepted for forward-compat but ignored in M1.
+  try {
+    await request.json().catch(() => ({}));
+  } catch {
+    // Non-JSON body is fine for the unconditional M1 ping.
+  }
+
+  const db = getDb();
+  const { eq, and, isNotNull } = await import("drizzle-orm");
+
+  // Users who have opted into Coomander AND have a Telegram destination.
+  const recipients = await db
+    .select({ id: user.id, chatId: user.telegramChatId })
+    .from(user)
+    .where(and(eq(user.coomanderEnabled, 1), isNotNull(user.telegramChatId)));
+
+  const results: Array<{ userId: string; sent: boolean; messageId?: number; error?: string }> = [];
+
+  for (const r of recipients) {
+    const chatId = r.chatId ?? "";
+    const send = await sendTelegram(chatId, PLACEHOLDER_MESSAGE);
+
+    // Persist the outbound message to the no-TTL log regardless of send outcome,
+    // so the substrate captures intent even if Telegram delivery failed.
+    try {
+      await db.insert(coomanderMessageLog).values({
+        id: crypto.randomUUID(),
+        user_id: r.id,
+        direction: "outbound",
+        telegram_update_id: null,
+        text: PLACEHOLDER_MESSAGE,
+        tool_call_json: null,
+        persona_mode: "light_companion",
+        created_at: Math.floor(Date.now() / 1000),
+      });
+    } catch (e) {
+      log.error("[POST /api/coomander/run] failed to log outbound message", {
+        error: e instanceof Error ? e.message : String(e),
+        userId: r.id,
+      });
+    }
+
+    if (!send.ok) {
+      log.warn("[POST /api/coomander/run] telegram send failed", { userId: r.id, error: send.error });
+    }
+    results.push({ userId: r.id, sent: send.ok, messageId: send.messageId, error: send.error });
+  }
+
+  log.info("[POST /api/coomander/run] complete", {
+    recipients: recipients.length,
+    sent: results.filter((x) => x.sent).length,
+  });
+
+  return NextResponse.json({ ok: true, recipients: recipients.length, results });
+}

--- a/node/app/api/coomander/run/route.ts
+++ b/node/app/api/coomander/run/route.ts
@@ -1,5 +1,5 @@
 /**
- * POST /api/coomander/run — Coomander cron entrypoint (#151, milestone 1).
+ * POST /api/coomander/run — Coomander cron entrypoint (#151).
  *
  * Fired by the Cloudflare cron (see custom-worker.ts), not a browser, so there
  * is no user session. Guarded by a shared secret: the caller must send
@@ -7,30 +7,22 @@
  * 401 on mismatch. Always returns 200 with a status object on the happy path so
  * the cron never sees a 500 and retry-storms.
  *
- * MILESTONE 1 SCOPE (deliberately minimal — see docs/strategy/next-session-brief.md §6):
- *   - No planPing decision logic yet: the ping is UNCONDITIONAL (good for testing).
- *   - No slot routing: the request body's `slot` is accepted but ignored.
- *   - Iterate every user with `coomanderEnabled = 1` AND a `telegramChatId`,
- *     send a fixed placeholder message, and log each send to
- *     `coomander_message_log` (the indefinite-retention substrate).
- *
- * Decision logic, per-slot persona prompts, and nag presets land in later
- * milestones.
+ * Body: `{ slot: "morning" | "midday" | "check" | "evening" }`. The handler
+ * fans out to every opted-in user with a Telegram chat id and calls
+ * `runAgentPing(userId, slot)`, which internally consults each user's nag
+ * preset (planPing) before deciding to send. A missing/invalid slot defaults to
+ * "check" (the lightest touchpoint) so a bare manual curl still works.
  */
 
 import { NextResponse } from "next/server";
-import crypto from "crypto";
-import { getDb } from "@/lib/db";
-import { user, coomanderMessageLog } from "@/lib/schema";
-import { sendTelegram } from "@/lib/coomander/telegram";
+import { runAgentPing } from "@/lib/coomander/agent";
+import { usersToPing } from "@/lib/coomander/settings";
+import { SLOTS, type Slot } from "@/lib/coomander/agentPrompts";
 import { log } from "@/lib/logger";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
-
-// PLACEHOLDER — real persona-driven content lands in #153. This fixed string
-// only proves the cron → route → Telegram → log path end-to-end.
-const PLACEHOLDER_MESSAGE = "Coomander online — this is a test ping. The infra works.";
+export const maxDuration = 290; // generous headroom for fan-out + model calls
 
 export async function POST(request: Request) {
   const secret = process.env.COOMANDER_RUN_SECRET;
@@ -41,58 +33,33 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  // Body is optional; `slot` is accepted for forward-compat but ignored in M1.
+  let body: { slot?: unknown } = {};
   try {
-    await request.json().catch(() => ({}));
+    body = (await request.json()) ?? {};
   } catch {
-    // Non-JSON body is fine for the unconditional M1 ping.
+    body = {};
   }
 
-  const db = getDb();
-  const { eq, and, isNotNull } = await import("drizzle-orm");
+  const slot: Slot = SLOTS.includes(body.slot as Slot) ? (body.slot as Slot) : "check";
 
-  // Users who have opted into Coomander AND have a Telegram destination.
-  const recipients = await db
-    .select({ id: user.id, chatId: user.telegramChatId })
-    .from(user)
-    .where(and(eq(user.coomanderEnabled, 1), isNotNull(user.telegramChatId)));
+  const recipients = await usersToPing();
+  const results = await Promise.all(
+    recipients.map((r) =>
+      runAgentPing(r.userId, slot)
+        .then((res) => ({ userId: r.userId, ...res }))
+        .catch((e) => ({ userId: r.userId, ok: false, slot, sent: false, error: (e as Error).message })),
+    ),
+  );
 
-  const results: Array<{ userId: string; sent: boolean; messageId?: number; error?: string }> = [];
-
-  for (const r of recipients) {
-    const chatId = r.chatId ?? "";
-    const send = await sendTelegram(chatId, PLACEHOLDER_MESSAGE);
-
-    // Persist the outbound message to the no-TTL log regardless of send outcome,
-    // so the substrate captures intent even if Telegram delivery failed.
-    try {
-      await db.insert(coomanderMessageLog).values({
-        id: crypto.randomUUID(),
-        user_id: r.id,
-        direction: "outbound",
-        telegram_update_id: null,
-        text: PLACEHOLDER_MESSAGE,
-        tool_call_json: null,
-        persona_mode: "light_companion",
-        created_at: Math.floor(Date.now() / 1000),
-      });
-    } catch (e) {
-      log.error("[POST /api/coomander/run] failed to log outbound message", {
-        error: e instanceof Error ? e.message : String(e),
-        userId: r.id,
-      });
-    }
-
-    if (!send.ok) {
-      log.warn("[POST /api/coomander/run] telegram send failed", { userId: r.id, error: send.error });
-    }
-    results.push({ userId: r.id, sent: send.ok, messageId: send.messageId, error: send.error });
+  for (const r of results) {
+    if (!r.ok) log.warn("[POST /api/coomander/run] ping failed", { userId: r.userId, slot, error: r.error });
   }
 
   log.info("[POST /api/coomander/run] complete", {
+    slot,
     recipients: recipients.length,
-    sent: results.filter((x) => x.sent).length,
+    sent: results.filter((r) => r.sent).length,
   });
 
-  return NextResponse.json({ ok: true, recipients: recipients.length, results });
+  return NextResponse.json({ ok: true, slot, recipients: recipients.length, results });
 }

--- a/node/app/api/coomander/settings/route.ts
+++ b/node/app/api/coomander/settings/route.ts
@@ -1,0 +1,73 @@
+/**
+ * GET|PATCH /api/coomander/settings — the session user's Coomander settings (#151).
+ *
+ * GET returns the resolved settings (defaults applied when no row exists).
+ * PATCH updates the nag preset and/or persona mode. Per-user overrides persist
+ * in `coomander_settings` (DB, not env), so they survive deploys.
+ */
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import {
+  getCoomanderSettings,
+  updateCoomanderSettings,
+  isValidNagFrequency,
+  isValidPersonaMode,
+  type SettingsPatch,
+} from "@/lib/coomander/settings";
+import { UnauthorizedError, BadRequestError, errorResponse } from "@/lib/errors";
+import { log } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  try {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) throw new UnauthorizedError();
+    const settings = await getCoomanderSettings(session.user.id);
+    return NextResponse.json({ settings });
+  } catch (error) {
+    log.error("GET /api/coomander/settings failed", { error });
+    return errorResponse(error);
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) throw new UnauthorizedError();
+
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const patch: SettingsPatch = {};
+
+    if (body.nagFrequency !== undefined) {
+      if (!isValidNagFrequency(body.nagFrequency)) {
+        throw new BadRequestError("nagFrequency must be one of: tight, moderate, light");
+      }
+      patch.nagFrequency = body.nagFrequency;
+    }
+    if (body.personaMode !== undefined) {
+      if (!isValidPersonaMode(body.personaMode)) {
+        throw new BadRequestError("personaMode must be one of: light_companion, full_companion, operational");
+      }
+      patch.personaMode = body.personaMode;
+    }
+    if (body.pingTimesJson !== undefined) {
+      if (body.pingTimesJson !== null && typeof body.pingTimesJson !== "string") {
+        throw new BadRequestError("pingTimesJson must be a string or null");
+      }
+      patch.pingTimesJson = body.pingTimesJson as string | null;
+    }
+
+    if (Object.keys(patch).length === 0) {
+      throw new BadRequestError("no valid fields to update");
+    }
+
+    const settings = await updateCoomanderSettings(session.user.id, patch);
+    return NextResponse.json({ settings });
+  } catch (error) {
+    log.error("PATCH /api/coomander/settings failed", { error });
+    return errorResponse(error);
+  }
+}

--- a/node/app/api/coomander/webhook/route.ts
+++ b/node/app/api/coomander/webhook/route.ts
@@ -1,0 +1,93 @@
+/**
+ * POST /api/coomander/webhook — inbound Telegram updates for @coomander_bot (#151).
+ *
+ * The creator replies in plain language; we classify it (placeholder
+ * need_clarification tool for now) and reply. Both the inbound message (with the
+ * classifier's tool-call JSON) and the outbound reply are persisted to the
+ * no-TTL `coomander_message_log`.
+ *
+ * Security: Telegram echoes the secret_token set at webhook registration in the
+ * `x-telegram-bot-api-secret-token` header. We reject a mismatch (401) and 503
+ * if `MADDIE_TELEGRAM_WEBHOOK_SECRET` is unset. Every other outcome returns 200
+ * so Telegram does not retry-storm. Unknown chats get a one-line hint.
+ *
+ * Ported from ~/Code/geology/web/node/app/api/telegram/webhook/route.ts,
+ * simplified to Coomander's user-row chat mapping (no link-code flow).
+ */
+
+import { NextResponse } from "next/server";
+import { handleInbound } from "@/lib/coomander/inbound";
+import { claimUpdate } from "@/lib/coomander/telegramDedup";
+import { sendTelegram } from "@/lib/coomander/telegram";
+import { resolveUserByChatId, getCoomanderSettings } from "@/lib/coomander/settings";
+import { appendMessage } from "@/lib/coomander/coomanderMessages";
+import { log } from "@/lib/logger";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 60; // Telegram retries until a 2xx; stay inside its timeout
+
+export async function POST(request: Request) {
+  const secret = process.env.MADDIE_TELEGRAM_WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "MADDIE_TELEGRAM_WEBHOOK_SECRET not configured" }, { status: 503 });
+  }
+  if (request.headers.get("x-telegram-bot-api-secret-token") !== secret) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let update: { update_id?: number; message?: { text?: string; chat?: { id?: number | string } } };
+  try {
+    update = await request.json();
+  } catch {
+    return NextResponse.json({ ok: true, ignored: "invalid JSON" });
+  }
+
+  let chatId: string | null = null;
+  try {
+    const updateId = update.update_id;
+    const text = update.message?.text;
+    chatId = update.message?.chat?.id != null ? String(update.message.chat.id) : null;
+
+    // Ignore non-text updates (stickers, edits, joins, etc.).
+    if (typeof updateId !== "number" || !text || !chatId) {
+      return NextResponse.json({ ok: true, ignored: "non-text update" });
+    }
+
+    // Unknown chat -> a one-line hint, nothing persisted.
+    const userId = await resolveUserByChatId(chatId);
+    if (!userId) {
+      await sendTelegram(
+        chatId,
+        "I do not recognize this chat yet. Enable Coomander in MaddieHQ and link this Telegram to start.",
+      );
+      return NextResponse.json({ ok: true, ignored: "unlinked chat" });
+    }
+
+    // De-dup: a redelivered update must never double-process.
+    const fresh = await claimUpdate(updateId, userId);
+    if (!fresh) return NextResponse.json({ ok: true, ignored: "duplicate update" });
+
+    const settings = await getCoomanderSettings(userId);
+    const result = await handleInbound(userId, text, settings.personaMode);
+
+    // Persist inbound (with the classifier tool-call) + outbound to the substrate.
+    await appendMessage(userId, "inbound", text, {
+      personaMode: settings.personaMode,
+      telegramUpdateId: updateId,
+      toolCall: result.toolCall ?? undefined,
+    }).catch(() => {});
+
+    await sendTelegram(chatId, result.reply);
+    await appendMessage(userId, "outbound", result.reply, { personaMode: settings.personaMode }).catch(() => {});
+
+    return NextResponse.json({ ok: true, classified: result.toolCall?.toolName ?? null });
+  } catch (e) {
+    // Always 200 so Telegram does not retry-storm.
+    log.error("[POST /api/coomander/webhook]", { error: e instanceof Error ? e.message : String(e) });
+    if (chatId) {
+      await sendTelegram(chatId, "Something went wrong on my end. Try again in a moment.").catch(() => {});
+    }
+    return NextResponse.json({ ok: true, error: (e as Error).message });
+  }
+}

--- a/node/custom-worker.ts
+++ b/node/custom-worker.ts
@@ -14,9 +14,10 @@
  * secret. That reuses the route's auth + Cloudflare context (D1 binding, env)
  * exactly as a real request would.
  *
- * MILESTONE 1: a single test cron (see wrangler.toml `[triggers]`). The ping is
- * unconditional and slot-agnostic; the route ignores the `slot` field for now.
- * Per-slot routing + planPing decision logic land in later milestones.
+ * The fired cron expression maps to a slot (tight-preset times). The run route
+ * then fans out to opted-in users and applies each user's nag preset (planPing)
+ * before deciding whether to actually send. Keep CRON_SLOT in sync with
+ * wrangler.toml `[triggers]` and lib/coomander/scheduling.ts CRON_SLOT_MAP.
  *
  * Unlike geology there is no Sentry wrapper here — MaddieHQ does not depend on
  * @sentry/cloudflare. If server-side capture is added later, wrap `worker` the
@@ -24,21 +25,30 @@
  */
 import { default as handler } from "./.open-next/worker.js";
 
+// Tight-preset cron (UTC) -> slot. Mirror of scheduling.ts CRON_SLOT_MAP.
+const CRON_SLOT = {
+  "0 12 * * *": "morning",
+  "0 18 * * *": "midday",
+  "0 21 * * *": "check",
+  "0 1 * * *": "evening",
+};
+
 const worker = {
   fetch: handler.fetch,
 
   async scheduled(event, env, ctx) {
+    const slot = CRON_SLOT[event.cron] ?? "check";
     const req = new Request("https://maddiehq.oqodo.com/api/coomander/run", {
       method: "POST",
       headers: {
         "content-type": "application/json",
         "x-agent-secret": env.COOMANDER_RUN_SECRET ?? "",
       },
-      body: JSON.stringify({ slot: "check" }),
+      body: JSON.stringify({ slot }),
     });
     const res = await handler.fetch(req, env, ctx);
     const body = await res.text().catch(() => "");
-    console.log(`[cron] coomander cron="${event.cron}" -> ${res.status} ${body}`);
+    console.log(`[cron] coomander cron="${event.cron}" slot="${slot}" -> ${res.status} ${body}`);
   },
 };
 

--- a/node/custom-worker.ts
+++ b/node/custom-worker.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+/**
+ * Custom Worker entrypoint (#151) — wraps the OpenNext-generated worker to add a
+ * Cloudflare Cron Trigger handler for the Coomander ping loop. Per OpenNext's
+ * "Custom Worker" how-to: re-export `fetch` unchanged, add `scheduled()`.
+ *
+ * `wrangler.toml` `main` points here (not `.open-next/worker.js`). The import
+ * below resolves at deploy time, AFTER `opennextjs-cloudflare build` has emitted
+ * `.open-next/worker.js`. (@ts-nocheck because that file does not exist at
+ * project-typecheck time, only after a build.)
+ *
+ * The scheduled handler invokes the app's own `/api/coomander/run` route
+ * in-process via `handler.fetch` (no external network hop), passing the shared
+ * secret. That reuses the route's auth + Cloudflare context (D1 binding, env)
+ * exactly as a real request would.
+ *
+ * MILESTONE 1: a single test cron (see wrangler.toml `[triggers]`). The ping is
+ * unconditional and slot-agnostic; the route ignores the `slot` field for now.
+ * Per-slot routing + planPing decision logic land in later milestones.
+ *
+ * Unlike geology there is no Sentry wrapper here — MaddieHQ does not depend on
+ * @sentry/cloudflare. If server-side capture is added later, wrap `worker` the
+ * same way geology does.
+ */
+import { default as handler } from "./.open-next/worker.js";
+
+const worker = {
+  fetch: handler.fetch,
+
+  async scheduled(event, env, ctx) {
+    const req = new Request("https://maddiehq.oqodo.com/api/coomander/run", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-agent-secret": env.COOMANDER_RUN_SECRET ?? "",
+      },
+      body: JSON.stringify({ slot: "check" }),
+    });
+    const res = await handler.fetch(req, env, ctx);
+    const body = await res.text().catch(() => "");
+    console.log(`[cron] coomander cron="${event.cron}" -> ${res.status} ${body}`);
+  },
+};
+
+export default worker;

--- a/node/lib/coomander/agent.ts
+++ b/node/lib/coomander/agent.ts
@@ -1,0 +1,142 @@
+/**
+ * Coomander ping loop (#151).
+ *
+ * `planPing` is a PURE, side-effect-free decision: given a slot, the user's nag
+ * preset, and (optionally) the day's quality, it decides whether to fire and
+ * why. No Anthropic, no Telegram, no DB — fully unit-testable.
+ *
+ * `runAgentPing` is the orchestration: resolve settings + chat id, plan, and on
+ * a "send" decision generate the message via Anthropic, send it to Telegram,
+ * persist it to the no-TTL log, stamp the day_state, and record token usage. It
+ * never throws — it returns a status object so the cron route always answers.
+ *
+ * Ported from ~/Code/geology/web/node/lib/geology/agent.ts, with geology's
+ * vein/carve domain logic removed (Coomander's domain model is #152): the
+ * suppression rules here are nag-preset based, not vein-activity based.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { sendTelegram } from "./telegram";
+import { coomanderSystem, slotPrompt, type Slot } from "./agentPrompts";
+import {
+  getCoomanderSettings,
+  type NagFrequency,
+  type PersonaMode,
+} from "./settings";
+import { getDayState, markSlotSent, todayUTC } from "./scheduling";
+import { appendMessage } from "./coomanderMessages";
+import { logCoomanderUsage } from "./usage";
+import { getDb } from "@/lib/db";
+import { user as userT } from "@/lib/schema";
+import { eq } from "drizzle-orm";
+
+const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
+
+/** Which slots each nag preset is allowed to fire. */
+export const PRESET_SLOTS: Record<NagFrequency, Slot[]> = {
+  tight: ["morning", "midday", "check", "evening"],
+  moderate: ["morning", "midday", "evening"],
+  light: ["morning", "evening"],
+};
+
+export interface PlanPingInput {
+  slot: Slot;
+  nagFrequency: NagFrequency;
+  /** Day quality from day_state; "bad" suppresses the midday/check touchpoints. */
+  dayQuality?: "good" | "bad" | null;
+}
+
+export interface PingPlan {
+  send: boolean;
+  reason?: string;
+}
+
+/**
+ * Pure decision: should we ping for this slot, given the user's nag preset?
+ *
+ * Rules (see docs/strategy/coomander-direction.md § Nag frequency):
+ *   - The slot must be in the preset's allowed set (light = morning+evening,
+ *     moderate = morning+midday+evening, tight = all four incl. the extra check).
+ *   - On a "bad" day the midday and check touchpoints are suppressed (morning
+ *     and evening anchors still fire).
+ */
+export function planPing(input: PlanPingInput): PingPlan {
+  const allowed = PRESET_SLOTS[input.nagFrequency] ?? PRESET_SLOTS.tight;
+  if (!allowed.includes(input.slot)) {
+    return { send: false, reason: `${input.slot} is not in the '${input.nagFrequency}' preset` };
+  }
+  if ((input.slot === "midday" || input.slot === "check") && input.dayQuality === "bad") {
+    return { send: false, reason: "bad-day mode: midday/check suppressed" };
+  }
+  return { send: true };
+}
+
+export interface AgentRunResult {
+  ok: boolean;
+  slot: Slot;
+  sent: boolean;
+  skipped?: string;
+  message?: string;
+  error?: string;
+}
+
+/** Resolve the user's Telegram chat id from the user row. */
+async function chatIdFor(userId: string): Promise<string | null> {
+  const db = getDb();
+  const rows = (await db
+    .select({ chatId: userT.telegramChatId })
+    .from(userT)
+    .where(eq(userT.id, userId))
+    .limit(1)) as Array<{ chatId: string | null }>;
+  return rows[0]?.chatId ?? null;
+}
+
+/** Generate the message text via Anthropic. Logs usage best-effort. */
+async function generateMessage(
+  userId: string,
+  slot: Slot,
+  personaMode: PersonaMode,
+): Promise<string> {
+  const client = new Anthropic();
+  const msg = await client.messages.create({
+    model: MODEL,
+    max_tokens: 300,
+    system: [{ type: "text", text: coomanderSystem(personaMode), cache_control: { type: "ephemeral" } }],
+    messages: [{ role: "user", content: slotPrompt(slot, personaMode) }],
+  });
+  await logCoomanderUsage(userId, slot, MODEL, msg.usage?.input_tokens, msg.usage?.output_tokens);
+  return msg.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("")
+    .trim();
+}
+
+/**
+ * Run the ping for one user + slot. Never throws.
+ */
+export async function runAgentPing(userId: string, slot: Slot): Promise<AgentRunResult> {
+  try {
+    const chatId = await chatIdFor(userId);
+    if (!chatId) return { ok: true, slot, sent: false, skipped: "no telegram chat id" };
+
+    const settings = await getCoomanderSettings(userId);
+    const date = todayUTC();
+    const day = await getDayState(userId, date);
+    const plan = planPing({ slot, nagFrequency: settings.nagFrequency, dayQuality: day?.day_quality ?? null });
+    if (!plan.send) return { ok: true, slot, sent: false, skipped: plan.reason };
+
+    const message = await generateMessage(userId, slot, settings.personaMode);
+    if (!message) return { ok: false, slot, sent: false, error: "empty message from model" };
+
+    const res = await sendTelegram(chatId, message);
+    if (!res.ok) return { ok: false, slot, sent: false, message, error: res.error };
+
+    // Persist + stamp are best-effort: a logging hiccup must not fail the send.
+    await appendMessage(userId, "outbound", message, { personaMode: settings.personaMode }).catch(() => {});
+    await markSlotSent(userId, slot, date).catch(() => {});
+    return { ok: true, slot, sent: true, message };
+  } catch (e) {
+    return { ok: false, slot, sent: false, error: (e as Error).message };
+  }
+}

--- a/node/lib/coomander/agentPrompts.ts
+++ b/node/lib/coomander/agentPrompts.ts
@@ -1,0 +1,94 @@
+/**
+ * Coomander persona + per-slot prompt templates (#151).
+ *
+ * Ported in spirit from ~/Code/geology/web/node/lib/geology/agentPrompts.ts, but
+ * adapted to Coomander's voice and (for now) WITHOUT a domain-state context —
+ * the ops domain model (pillars, beats, drops, content-cushion days) lands in
+ * #152, and the real persona/playbook lands in #153. Until then these templates
+ * shape a warm, generic nudge so the cron → Anthropic → Telegram pipeline is
+ * exercisable end-to-end.
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ PLACEHOLDER — revise in #153.                                             │
+ * │ The system prompt's TONE and HARD RULES below are real and load-bearing   │
+ * │ (light-companion warmth, data-grounded praise only, OF comms boundaries). │
+ * │ The per-slot user prompts are placeholders: they cannot yet reference the │
+ * │ creator's real ops state because the domain model (#152) does not exist.  │
+ * │ Replace the slot bodies with state-grounded content once #152 + #153 land.│
+ * └─────────────────────────────────────────────────────────────────────────┘
+ */
+
+import type { PersonaMode } from "./settings";
+
+export type Slot = "morning" | "midday" | "check" | "evening";
+
+export const SLOTS: Slot[] = ["morning", "midday", "check", "evening"];
+
+/**
+ * Coomander's system prompt. Persona is the validated "light companion": warm,
+ * direct, slightly tongue-in-cheek, NOT corporate. Praise is DATA-GROUNDED ONLY
+ * (never generic). See docs/strategy/coomander-direction.md § Persona.
+ *
+ * full_companion is reserved for later (persistent life-memory); until that
+ * ships it behaves like light_companion but is allowed marginally warmer
+ * small-talk. operational is a terse, no-warmth mode for users who opt out.
+ */
+export function coomanderSystem(personaMode: PersonaMode = "light_companion"): string {
+  const toneByMode: Record<PersonaMode, string> = {
+    light_companion:
+      "Voice: warm, direct, a little tongue-in-cheek. A real manager who is in the creator's corner, not a corporate assistant and not a hype bot.",
+    full_companion:
+      "Voice: warm and familiar, like a manager who knows the creator well. You MUST NOT fabricate personal details you were not given; if you do not know something about her life, do not pretend to.",
+    operational:
+      "Voice: terse and practical. Minimal warmth. Just the operationally useful nudge, nothing else.",
+  };
+
+  return `You are Coomander, the AI operations manager inside MaddieHQ, an app for OnlyFans creators. You keep the creator on cadence across her content workflow (Instagram reels as top-of-funnel, OF wall + PPV monetization).
+
+${toneByMode[personaMode]}
+
+Hard rules:
+- Output ONLY the message text to send on Telegram. No preamble, no quotation marks, no labels.
+- 1 to 4 sentences. Conversational and voice-message friendly.
+- Never use em-dashes. Use commas, periods, or parentheses instead.
+- Praise is DATA-GROUNDED ONLY. Never generic praise. Only celebrate a specific number or milestone you were actually given. If you have no data to praise, do not praise, just nudge.
+- You remind and support; you NEVER claim to have published, sent, or posted anything on the creator's behalf.
+- Never draft or imply outbound messages to fans on Instagram, TikTok, Facebook, or Snapchat. Those channels are off-limits (see the communication policy).
+- Never invent activity, metrics, or fan/chat details you were not given.`;
+}
+
+function placeholderNote(): string {
+  // Until #152 ships there is no ops-state context to inject. Be honest about it
+  // in the instruction so the model produces a light check-in, not invented data.
+  return "You do not yet have access to today's content plan or metrics, so do not reference specific posts, numbers, or tasks. Keep it a light, human check-in.";
+}
+
+export function morningPrompt(personaMode: PersonaMode = "light_companion"): string {
+  return `It is morning. Send a short, warm kickoff that opens the day and invites the creator to share her rough plan for content today. ${placeholderNote()} Keep it to 1 to 3 sentences.`;
+}
+
+export function middayPrompt(personaMode: PersonaMode = "light_companion"): string {
+  return `It is the middle of the day. Send a brief, low-pressure nudge checking in on how filming or posting is going, framed as an opportunity rather than a scold. ${placeholderNote()} Keep it to 1 to 2 sentences.`;
+}
+
+export function checkPrompt(personaMode: PersonaMode = "light_companion"): string {
+  return `It is mid-afternoon, a second light touchpoint. Send a very short, friendly check-in, gentler than a reminder. ${placeholderNote()} Keep it to 1 to 2 sentences.`;
+}
+
+export function eveningPrompt(personaMode: PersonaMode = "light_companion"): string {
+  return `It is evening. Send a short, non-judgmental wind-down: ask what got done today and whether there is anything to line up for tomorrow. Curious, not evaluative. ${placeholderNote()} Keep it to 1 to 3 sentences.`;
+}
+
+/** The user-turn prompt for a given slot. */
+export function slotPrompt(slot: Slot, personaMode: PersonaMode = "light_companion"): string {
+  switch (slot) {
+    case "morning":
+      return morningPrompt(personaMode);
+    case "midday":
+      return middayPrompt(personaMode);
+    case "check":
+      return checkPrompt(personaMode);
+    case "evening":
+      return eveningPrompt(personaMode);
+  }
+}

--- a/node/lib/coomander/coomanderChat.ts
+++ b/node/lib/coomander/coomanderChat.ts
@@ -1,0 +1,36 @@
+/**
+ * Coomander two-way conversation state (#151).
+ *
+ * A thin layer over `coomander_message_log` that exposes the running thread as
+ * Anthropic-shaped turns, so future milestones can give the classifier and the
+ * in-app chat conversational context (and so the full-companion layer has a
+ * ready source of history). Outbound Coomander messages map to the "assistant"
+ * role, inbound creator messages to "user".
+ *
+ * Ported/simplified from ~/Code/geology/web/node/lib/geology/geoChat.ts — the
+ * geology version also drives an in-app chat endpoint; that surface is deferred
+ * for Coomander, so this keeps only the history/context helpers.
+ */
+
+import { listMessages, type CoomanderMessage } from "./coomanderMessages";
+
+export type ChatRole = "user" | "assistant";
+
+export interface ChatTurn {
+  role: ChatRole;
+  content: string;
+}
+
+/** Map a stored message's direction to an Anthropic chat role. */
+export function roleForDirection(direction: CoomanderMessage["direction"]): ChatRole {
+  return direction === "inbound" ? "user" : "assistant";
+}
+
+/**
+ * The recent thread as Anthropic-shaped turns, oldest-first, ready to prepend to
+ * a `messages.create` call. Defaults to the last 20 turns.
+ */
+export async function recentTurns(userId: string, limit = 20): Promise<ChatTurn[]> {
+  const messages = await listMessages(userId, limit);
+  return messages.map((m) => ({ role: roleForDirection(m.direction), content: m.text }));
+}

--- a/node/lib/coomander/coomanderMessages.ts
+++ b/node/lib/coomander/coomanderMessages.ts
@@ -1,0 +1,109 @@
+/**
+ * Coomander conversation log (#151).
+ *
+ * Every outbound Coomander message AND inbound creator reply is appended to
+ * `coomander_message_log`. This is the INDEFINITE-RETENTION companion-memory
+ * substrate: there is no TTL, no cleanup sweep, ever (see migration 016 /
+ * schema comment). Each row also records the persona mode in effect and, for
+ * inbound, the classifier's tool-call JSON.
+ *
+ * Ported from ~/Code/geology/web/node/lib/geology/geoMessages.ts.
+ */
+
+import crypto from "crypto";
+import { and, eq, gt, asc, desc } from "drizzle-orm";
+import { getDb } from "@/lib/db";
+import { coomanderMessageLog as logT } from "@/lib/schema";
+import type { PersonaMode } from "./settings";
+
+export type Direction = "inbound" | "outbound";
+
+export interface CoomanderMessage {
+  id: string;
+  direction: Direction;
+  text: string;
+  telegramUpdateId: number | null;
+  toolCall: Record<string, unknown> | null;
+  personaMode: string;
+  createdAt: number;
+}
+
+export interface AppendOptions {
+  personaMode?: PersonaMode;
+  telegramUpdateId?: number | null;
+  /** Any JSON-serializable classifier output (e.g. the forced tool call). */
+  toolCall?: unknown;
+}
+
+/**
+ * Append one message to a user's Coomander log. Returns the new row id.
+ * Callers on a hot path (a ping that must still succeed if logging hiccups)
+ * should wrap this in a try/catch — it does not swallow its own errors.
+ */
+export async function appendMessage(
+  userId: string,
+  direction: Direction,
+  text: string,
+  opts: AppendOptions = {},
+): Promise<string | null> {
+  const body = (text ?? "").trim();
+  if (!body) return null;
+  const db = getDb();
+  const id = crypto.randomUUID();
+  await db.insert(logT).values({
+    id,
+    user_id: userId,
+    direction,
+    telegram_update_id: opts.telegramUpdateId ?? null,
+    text: body,
+    tool_call_json: opts.toolCall != null ? JSON.stringify(opts.toolCall) : null,
+    persona_mode: opts.personaMode ?? "light_companion",
+    created_at: Math.floor(Date.now() / 1000),
+  });
+  return id;
+}
+
+function hydrate(
+  rows: Array<{
+    id: string;
+    direction: string;
+    text: string;
+    telegram_update_id: number | null;
+    tool_call_json: string | null;
+    persona_mode: string;
+    created_at: number;
+  }>,
+): CoomanderMessage[] {
+  return rows.map((r) => ({
+    id: r.id,
+    direction: r.direction as Direction,
+    text: r.text,
+    telegramUpdateId: r.telegram_update_id,
+    toolCall: r.tool_call_json ? (JSON.parse(r.tool_call_json) as Record<string, unknown>) : null,
+    personaMode: r.persona_mode,
+    createdAt: r.created_at,
+  }));
+}
+
+/** The most recent `limit` messages, oldest-first for rendering. */
+export async function listMessages(userId: string, limit = 100): Promise<CoomanderMessage[]> {
+  const db = getDb();
+  const rows = (await db
+    .select()
+    .from(logT)
+    .where(eq(logT.user_id, userId))
+    .orderBy(desc(logT.created_at))
+    .limit(limit)) as unknown as Parameters<typeof hydrate>[0];
+  return hydrate(rows).reverse();
+}
+
+/** Messages created after a unix-seconds cursor (for polling), oldest-first. */
+export async function messagesSince(userId: string, sinceSeconds: number): Promise<CoomanderMessage[]> {
+  const db = getDb();
+  const rows = (await db
+    .select()
+    .from(logT)
+    .where(and(eq(logT.user_id, userId), gt(logT.created_at, sinceSeconds)))
+    .orderBy(asc(logT.created_at))) as unknown as Parameters<typeof hydrate>[0];
+  return hydrate(rows);
+}

--- a/node/lib/coomander/inbound.ts
+++ b/node/lib/coomander/inbound.ts
@@ -1,0 +1,119 @@
+/**
+ * Inbound Telegram message handling for Coomander (#151).
+ *
+ * The creator replies to Coomander in plain language; we classify the message
+ * with Anthropic tool-use. For the V1 infra landing the ONLY tool is the
+ * placeholder `need_clarification`, so the full classify → resolve → persist
+ * pipeline is exercisable end-to-end. The real domain tools (log_drop,
+ * log_purchase, mark_blocker, add_procurement, ...) are domain-specific and
+ * land with #152 — swap them into `tools()` then.
+ *
+ * The Anthropic call (classifyMessage) is isolated from the pure resolution of
+ * its result (resolveToolUse), so the matching logic is unit-testable without
+ * the network.
+ *
+ * Ported/simplified from ~/Code/geology/web/node/lib/geology/inbound.ts.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { logCoomanderUsage } from "./usage";
+import type { PersonaMode } from "./settings";
+
+const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
+
+export const CLARIFY_TOOL = "need_clarification";
+
+/** Generic fallback when the model returns no usable tool call. */
+const FALLBACK_REPLY =
+  "Got it. I can not action that yet, but I logged it. Once your content tracking is wired up I will be able to do more with messages like this.";
+
+export interface ClassifiedTool {
+  toolName: string;
+  input: Record<string, unknown>;
+}
+
+export type InboundAction = { action: "clarify"; reply: string };
+
+export interface InboundResult {
+  reply: string;
+  /** The raw tool call, persisted alongside the inbound message for the substrate. */
+  toolCall: ClassifiedTool | null;
+}
+
+function tools(): Anthropic.Tool[] {
+  return [
+    {
+      // PLACEHOLDER — the only tool until #152's domain tools land.
+      name: CLARIFY_TOOL,
+      description:
+        "Acknowledge the creator's message and, if useful, ask one short clarifying question. This is the ONLY action available right now: Coomander cannot yet log drops, purchases, blockers, or procurement items (those domain tools arrive later). Always call this tool.",
+      input_schema: {
+        type: "object",
+        properties: {
+          reply: {
+            type: "string",
+            description: "A short, warm one or two sentence reply back to the creator. No em-dashes.",
+          },
+        },
+        required: ["reply"],
+      },
+    },
+  ];
+}
+
+function systemPrompt(personaMode: PersonaMode): string {
+  return `You are Coomander, the AI operations manager inside MaddieHQ (an OnlyFans creator app). The creator just sent you a Telegram message. ${
+    personaMode === "operational" ? "Be terse and practical." : "Be warm, direct, and a little tongue-in-cheek."
+  }
+
+You cannot take any operational action yet (content tracking is not wired up), so always call need_clarification with a short, friendly reply that acknowledges what she said. Do not invent metrics, posts, or fan details. Never use em-dashes.`;
+}
+
+/**
+ * Pure resolution of a forced tool call. No network, no DB. Returns the action
+ * the caller acts on.
+ */
+export function resolveToolUse(toolName: string, input: Record<string, unknown>): InboundAction {
+  if (toolName === CLARIFY_TOOL) {
+    const reply = typeof input.reply === "string" && input.reply.trim() ? input.reply.trim() : FALLBACK_REPLY;
+    return { action: "clarify", reply };
+  }
+  return { action: "clarify", reply: FALLBACK_REPLY };
+}
+
+/** Force the model to choose a tool. Isolated so handleInbound stays testable. */
+async function classifyMessage(
+  userId: string,
+  text: string,
+  personaMode: PersonaMode,
+): Promise<ClassifiedTool | null> {
+  const client = new Anthropic();
+  const msg = await client.messages.create({
+    model: MODEL,
+    max_tokens: 200,
+    system: [{ type: "text", text: systemPrompt(personaMode), cache_control: { type: "ephemeral" } }],
+    tool_choice: { type: "any" },
+    tools: tools(),
+    messages: [{ role: "user", content: text }],
+  });
+  await logCoomanderUsage(userId, "inbound", MODEL, msg.usage?.input_tokens, msg.usage?.output_tokens);
+  const block = msg.content.find((b): b is Anthropic.ToolUseBlock => b.type === "tool_use");
+  if (!block) return null;
+  return { toolName: block.name, input: (block.input ?? {}) as Record<string, unknown> };
+}
+
+/**
+ * Full inbound flow: classify the message and resolve it to a reply. Returns the
+ * reply plus the raw tool call so the webhook can persist both. Throws only on
+ * unexpected failures; the webhook wraps this and still answers Telegram.
+ */
+export async function handleInbound(
+  userId: string,
+  text: string,
+  personaMode: PersonaMode = "light_companion",
+): Promise<InboundResult> {
+  const classified = await classifyMessage(userId, text, personaMode);
+  if (!classified) return { reply: FALLBACK_REPLY, toolCall: null };
+  const resolved = resolveToolUse(classified.toolName, classified.input);
+  return { reply: resolved.reply, toolCall: classified };
+}

--- a/node/lib/coomander/scheduling.ts
+++ b/node/lib/coomander/scheduling.ts
@@ -1,0 +1,86 @@
+/**
+ * Coomander cron scheduling (#151).
+ *
+ * Simpler than geology's per-user local-time scheduling (#89): Coomander fires
+ * on fixed-UTC Cloudflare crons for the default `tight` preset, and the
+ * `scheduled()` handler maps the cron expression that fired to a slot. Per-user
+ * nag-preset suppression then happens inside planPing (agent.ts), and per-user
+ * local-time ping windows are deferred (the `ping_times_json` override column
+ * exists for that future work).
+ *
+ * Cron times are UTC. Mark is in US Central; the tight-preset local intent is
+ * roughly morning 07:00, midday 13:00, check 16:00, evening 20:00 CT, translated
+ * to the UTC expressions below. They drift ~1h across DST; per-user local
+ * scheduling (a later milestone) removes that drift.
+ *
+ * The pure helper (cronToSlot) takes no DB and is unit-testable.
+ */
+
+import { and, eq } from "drizzle-orm";
+import { getDb } from "@/lib/db";
+import { coomanderDayState as dayT } from "@/lib/schema";
+import type { Slot } from "./agentPrompts";
+import { newId } from "./settings";
+
+/** Tight-preset cron expressions (UTC) → slot. Keep in sync with wrangler.toml. */
+export const CRON_SLOT_MAP: Record<string, Slot> = {
+  "0 12 * * *": "morning", // ~07:00 CT
+  "0 18 * * *": "midday", //  ~13:00 CT
+  "0 21 * * *": "check", //   ~16:00 CT
+  "0 1 * * *": "evening", //  ~20:00 CT (previous-day UTC)
+};
+
+/** Map a fired cron expression to its slot, or null if unrecognized. */
+export function cronToSlot(cron: string): Slot | null {
+  return CRON_SLOT_MAP[cron.trim()] ?? null;
+}
+
+/** Slot → the day_state column that records the send time. */
+export const SENT_COLUMN: Record<Slot, "morning_ping_sent_at" | "midday_ping_sent_at" | "evening_recap_at"> = {
+  morning: "morning_ping_sent_at",
+  midday: "midday_ping_sent_at",
+  // "check" is the second midday touchpoint; it shares the midday column.
+  check: "midday_ping_sent_at",
+  evening: "evening_recap_at",
+};
+
+/** Today's date as YYYY-MM-DD in UTC. */
+export function todayUTC(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+export interface DayState {
+  date: string;
+  morning_ping_sent_at: number | null;
+  midday_ping_sent_at: number | null;
+  evening_recap_at: number | null;
+  day_quality: "good" | "bad" | null;
+}
+
+/** Read a user's day_state row for a date, or null if none yet. */
+export async function getDayState(userId: string, date: string): Promise<DayState | null> {
+  const db = getDb();
+  const rows = (await db
+    .select()
+    .from(dayT)
+    .where(and(eq(dayT.user_id, userId), eq(dayT.date, date)))
+    .limit(1)) as unknown as DayState[];
+  return rows[0] ?? null;
+}
+
+/** Stamp a slot as delivered for the user's day (upserts the row). */
+export async function markSlotSent(userId: string, slot: Slot, date: string): Promise<void> {
+  const db = getDb();
+  const col = SENT_COLUMN[slot];
+  const now = Math.floor(Date.now() / 1000);
+  const existing = (await db
+    .select({ id: dayT.id })
+    .from(dayT)
+    .where(and(eq(dayT.user_id, userId), eq(dayT.date, date)))
+    .limit(1)) as Array<{ id: string }>;
+  if (existing[0]) {
+    await db.update(dayT).set({ [col]: now }).where(eq(dayT.id, existing[0].id));
+  } else {
+    await db.insert(dayT).values({ id: newId(), user_id: userId, date, [col]: now });
+  }
+}

--- a/node/lib/coomander/settings.ts
+++ b/node/lib/coomander/settings.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-user Coomander settings + recipient resolution (#151).
+ *
+ * Simpler than geology's settings.ts: there is no separate agents/channels/
+ * link-code machinery. The Telegram destination lives directly on the user row
+ * (`user.telegramChatId`) and the opt-in flag is `user.coomanderEnabled`.
+ * Agent config (nag preset, persona mode) lives in `coomander_settings`, with
+ * sensible defaults when no row exists.
+ *
+ * The pure pickers (pickNagFrequency / pickPersonaMode) are split out so they
+ * are unit-testable without a DB.
+ */
+
+import crypto from "crypto";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { getDb } from "@/lib/db";
+import { user as userT, coomanderSettings as settingsT } from "@/lib/schema";
+
+export type NagFrequency = "tight" | "moderate" | "light";
+export type PersonaMode = "light_companion" | "full_companion" | "operational";
+
+export const NAG_FREQUENCIES: NagFrequency[] = ["tight", "moderate", "light"];
+export const PERSONA_MODES: PersonaMode[] = ["light_companion", "full_companion", "operational"];
+
+export const DEFAULT_NAG_FREQUENCY: NagFrequency = "tight";
+export const DEFAULT_PERSONA_MODE: PersonaMode = "light_companion";
+
+export interface CoomanderSettingsResolved {
+  userId: string;
+  nagFrequency: NagFrequency;
+  personaMode: PersonaMode;
+  pingTimesJson: string | null;
+  companionConsentAt: number | null;
+}
+
+// ── Pure pickers (no DB) ─────────────────────────────────────────────────────
+
+type SettingsRow =
+  | {
+      nag_frequency?: string | null;
+      persona_mode?: string | null;
+      ping_times_json?: string | null;
+      companion_consent_at?: number | null;
+    }
+  | undefined;
+
+export function pickNagFrequency(row: SettingsRow): NagFrequency {
+  const v = (row?.nag_frequency ?? "").trim() as NagFrequency;
+  return NAG_FREQUENCIES.includes(v) ? v : DEFAULT_NAG_FREQUENCY;
+}
+
+export function pickPersonaMode(row: SettingsRow): PersonaMode {
+  const v = (row?.persona_mode ?? "").trim() as PersonaMode;
+  return PERSONA_MODES.includes(v) ? v : DEFAULT_PERSONA_MODE;
+}
+
+export function isValidNagFrequency(v: unknown): v is NagFrequency {
+  return typeof v === "string" && NAG_FREQUENCIES.includes(v as NagFrequency);
+}
+
+export function isValidPersonaMode(v: unknown): v is PersonaMode {
+  return typeof v === "string" && PERSONA_MODES.includes(v as PersonaMode);
+}
+
+// ── DB-backed resolution ─────────────────────────────────────────────────────
+
+async function settingsRow(userId: string): Promise<SettingsRow> {
+  const db = getDb();
+  const rows = await db.select().from(settingsT).where(eq(settingsT.user_id, userId)).limit(1);
+  return rows[0] as SettingsRow;
+}
+
+/** A user's resolved Coomander settings, falling back to defaults when unset. */
+export async function getCoomanderSettings(userId: string): Promise<CoomanderSettingsResolved> {
+  const row = await settingsRow(userId);
+  return {
+    userId,
+    nagFrequency: pickNagFrequency(row),
+    personaMode: pickPersonaMode(row),
+    pingTimesJson: row?.ping_times_json ?? null,
+    companionConsentAt: row?.companion_consent_at ?? null,
+  };
+}
+
+/** Each user the scheduled ping fans out to: opted-in AND with a Telegram chat. */
+export async function usersToPing(): Promise<Array<{ userId: string; chatId: string }>> {
+  const db = getDb();
+  const rows = (await db
+    .select({ userId: userT.id, chatId: userT.telegramChatId })
+    .from(userT)
+    .where(and(eq(userT.coomanderEnabled, 1), isNotNull(userT.telegramChatId)))) as Array<{
+    userId: string;
+    chatId: string | null;
+  }>;
+  return rows.filter((r): r is { userId: string; chatId: string } => !!r.chatId);
+}
+
+/** Map an inbound Telegram chat id to its user, or null if none matches. */
+export async function resolveUserByChatId(chatId: string): Promise<string | null> {
+  const db = getDb();
+  const rows = (await db
+    .select({ id: userT.id })
+    .from(userT)
+    .where(eq(userT.telegramChatId, chatId))
+    .limit(1)) as Array<{ id: string }>;
+  return rows[0]?.id ?? null;
+}
+
+// ── Mutations (Settings API) ─────────────────────────────────────────────────
+
+export interface SettingsPatch {
+  nagFrequency?: NagFrequency;
+  personaMode?: PersonaMode;
+  pingTimesJson?: string | null;
+}
+
+/** Upsert a user's Coomander settings. Only provided fields change. */
+export async function updateCoomanderSettings(
+  userId: string,
+  patch: SettingsPatch,
+): Promise<CoomanderSettingsResolved> {
+  const db = getDb();
+  const now = Math.floor(Date.now() / 1000);
+  const existing = await settingsRow(userId);
+
+  if (existing) {
+    const set: Record<string, unknown> = { updated_at: now };
+    if (patch.nagFrequency !== undefined) set.nag_frequency = patch.nagFrequency;
+    if (patch.personaMode !== undefined) set.persona_mode = patch.personaMode;
+    if (patch.pingTimesJson !== undefined) set.ping_times_json = patch.pingTimesJson;
+    await db.update(settingsT).set(set).where(eq(settingsT.user_id, userId));
+  } else {
+    await db.insert(settingsT).values({
+      user_id: userId,
+      nag_frequency: patch.nagFrequency ?? DEFAULT_NAG_FREQUENCY,
+      persona_mode: patch.personaMode ?? DEFAULT_PERSONA_MODE,
+      ping_times_json: patch.pingTimesJson ?? null,
+      created_at: now,
+      updated_at: now,
+    });
+  }
+  return getCoomanderSettings(userId);
+}
+
+/** Generate a UUID (kept here so call sites don't each import crypto). */
+export function newId(): string {
+  return crypto.randomUUID();
+}

--- a/node/lib/coomander/telegram.ts
+++ b/node/lib/coomander/telegram.ts
@@ -1,0 +1,75 @@
+/**
+ * Outbound Telegram send for Coomander (#151, milestone 1).
+ *
+ * Ported from ~/Code/geology/web/node/lib/geology/telegram.ts, adapted for
+ * MaddieHQ's multi-tenant model: the caller passes the destination `chatId`
+ * (resolved from each user's `telegramChatId` row), and the bot token is the
+ * MaddieHQ-dedicated `MADDIE_TELEGRAM_BOT_TOKEN`.
+ *
+ * Posts directly to the Bot API so it works from a Cloudflare Worker or Node
+ * route with no MCP dependency. Never throws: returns a status object so the
+ * cron route can log a failure and still respond 200.
+ *
+ * IMPORTANT — difference from geology: geology suppresses all outbound Telegram
+ * whenever NODE_ENV != production, to avoid the dev server posting into the prod
+ * bot thread (it shares one bot across environments). MaddieHQ uses a DEDICATED
+ * bot (@coomander_bot), so there is no shared-thread hazard, and milestone 1's
+ * whole point is to verify an end-to-end send from the DEV environment. So this
+ * does NOT suppress in dev. `COOMANDER_TELEGRAM_DISABLED` is an explicit opt-out
+ * only (1/true to force off); it is NOT keyed off NODE_ENV. Per the deploy
+ * gotcha, never set a forcing value in `.env.local` — it would bake into the
+ * prod bundle.
+ */
+
+export interface TelegramSendResult {
+  ok: boolean;
+  messageId?: number;
+  error?: string;
+}
+
+/** Parse an explicit on/off override. null = not set. */
+function flagSet(v: string | undefined): boolean | null {
+  if (v == null || v === "") return null;
+  if (v === "1" || v === "true" || v === "yes" || v === "on") return true;
+  if (v === "0" || v === "false" || v === "no" || v === "off") return false;
+  return null;
+}
+
+/**
+ * Whether outbound Telegram is suppressed. Default: ENABLED everywhere (incl.
+ * dev), because the bot is MaddieHQ-dedicated. Only an explicit
+ * COOMANDER_TELEGRAM_DISABLED=1 turns it off.
+ */
+function telegramDisabled(): boolean {
+  return flagSet(process.env.COOMANDER_TELEGRAM_DISABLED) === true;
+}
+
+export async function sendTelegram(chatId: string, text: string): Promise<TelegramSendResult> {
+  if (telegramDisabled()) {
+    console.log(`[coomander/telegram] disabled via COOMANDER_TELEGRAM_DISABLED; skipped send to ${chatId}: ${text.slice(0, 80)}`);
+    return { ok: false, error: "telegram disabled via COOMANDER_TELEGRAM_DISABLED" };
+  }
+
+  const token = process.env.MADDIE_TELEGRAM_BOT_TOKEN;
+  if (!token) return { ok: false, error: "MADDIE_TELEGRAM_BOT_TOKEN not set" };
+  if (!chatId) return { ok: false, error: "no chatId" };
+
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text, disable_web_page_preview: true }),
+    });
+    const data = (await res.json().catch(() => ({}))) as {
+      ok?: boolean;
+      result?: { message_id?: number };
+      description?: string;
+    };
+    if (!res.ok || !data.ok) {
+      return { ok: false, error: data.description || `telegram http ${res.status}` };
+    }
+    return { ok: true, messageId: data.result?.message_id };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}

--- a/node/lib/coomander/telegramDedup.ts
+++ b/node/lib/coomander/telegramDedup.ts
@@ -1,0 +1,34 @@
+/**
+ * Inbound Telegram update de-duplication (#151).
+ *
+ * Telegram redelivers a webhook update until it receives a 2xx, so the same
+ * message can arrive more than once. We claim each update_id in `coomander_dedup`
+ * before processing. Telegram's retries are sequential (after a timeout), so a
+ * select-then-insert reliably catches a redelivery; onConflictDoNothing guards
+ * the rare exact-simultaneous case from throwing.
+ *
+ * Ported from ~/Code/geology/web/node/lib/geology/telegramDedup.ts.
+ */
+
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db";
+import { coomanderDedup as dedupT } from "@/lib/schema";
+
+/**
+ * Returns true if this update_id is new (and now claimed), false if it was
+ * already processed. A false result means the caller must NOT act on it again.
+ */
+export async function claimUpdate(updateId: number, userId: string): Promise<boolean> {
+  const db = getDb();
+  const existing = await db
+    .select()
+    .from(dedupT)
+    .where(eq(dedupT.telegram_update_id, updateId))
+    .limit(1);
+  if (existing.length > 0) return false;
+  await db
+    .insert(dedupT)
+    .values({ telegram_update_id: updateId, user_id: userId, processed_at: Math.floor(Date.now() / 1000) })
+    .onConflictDoNothing();
+  return true;
+}

--- a/node/lib/coomander/usage.ts
+++ b/node/lib/coomander/usage.ts
@@ -1,0 +1,64 @@
+/**
+ * Coomander Anthropic token-usage logging (#151, skeleton).
+ *
+ * Milestone 1 ships only the insert helper; nothing calls it yet (no Anthropic
+ * turn until the persona prompt + classifier land). It exists now so the
+ * write-path is stable for the milestones that add real model calls. The full
+ * cost-attribution math from geology's usage.ts (per-model rate table, cache
+ * buckets, monthly rollups) is intentionally deferred — `coomander_usage` only
+ * records raw token counts per the #151 schema.
+ *
+ * Best-effort: a logging failure must NEVER break a user-facing Coomander turn,
+ * so every error is swallowed.
+ */
+
+import crypto from "crypto";
+import { getDb } from "@/lib/db";
+import { coomanderUsage } from "@/lib/schema";
+import { log } from "@/lib/logger";
+
+/** The call sites usage is attributed to. */
+export type CoomanderSlot = "morning" | "midday" | "evening" | "check" | "inbound";
+
+/**
+ * Record one Anthropic response's raw token usage for a user. Never throws.
+ *
+ * @param userId        The user the spend is attributed to.
+ * @param slotOrInbound Which call site produced it.
+ * @param model         The Anthropic model id used.
+ * @param inputTokens   usage.input_tokens (defaults to 0 if absent).
+ * @param outputTokens  usage.output_tokens (defaults to 0 if absent).
+ */
+export async function logCoomanderUsage(
+  userId: string,
+  slotOrInbound: CoomanderSlot,
+  model: string,
+  inputTokens: number | null | undefined,
+  outputTokens: number | null | undefined,
+): Promise<void> {
+  if (!userId) return;
+  try {
+    const db = getDb();
+    await db.insert(coomanderUsage).values({
+      id: crypto.randomUUID(),
+      user_id: userId,
+      slot_or_inbound: slotOrInbound,
+      input_tokens: nonNeg(inputTokens),
+      output_tokens: nonNeg(outputTokens),
+      model,
+      created_at: Math.floor(Date.now() / 1000),
+    });
+  } catch (e) {
+    log.error("[coomander/usage] failed to persist token usage", {
+      error: e instanceof Error ? e.message : String(e),
+      userId,
+      slotOrInbound,
+      model,
+    });
+  }
+}
+
+function nonNeg(n: number | null | undefined): number {
+  const v = Number(n);
+  return Number.isFinite(v) && v > 0 ? Math.round(v) : 0;
+}

--- a/node/lib/schema.pg.ts
+++ b/node/lib/schema.pg.ts
@@ -30,6 +30,9 @@ export const user = pgTable("user", {
   subscriptionStatus: text("subscriptionStatus").default("inactive"),
   isAdmin: integer("isAdmin").notNull().default(0),
   disabled: integer("disabled").notNull().default(0),
+  // Coomander (#151): Telegram destination + opt-in flag for the ops agent.
+  telegramChatId: text("telegramChatId"),
+  coomanderEnabled: integer("coomanderEnabled").notNull().default(0),
 });
 
 export const session = pgTable("session", {
@@ -426,3 +429,62 @@ export const contentInsights = pgTable("content_insights", {
 }, (table) => [
   index("idx_content_insights_user_id").on(table.user_id),
 ]);
+
+// ─── Coomander — AI ops agent infrastructure (#151) ──────────────────────────
+// Mirrors schema.sqlite.ts. See migrations/016_coomander_infra.sql.
+
+export const coomanderSettings = pgTable("coomander_settings", {
+  user_id: text("user_id").primaryKey().references(() => user.id, { onDelete: "cascade" }),
+  nag_frequency: text("nag_frequency").notNull().default("tight"),
+  persona_mode: text("persona_mode").notNull().default("light_companion"),
+  ping_times_json: text("ping_times_json"),
+  companion_consent_at: integer("companion_consent_at"),
+  created_at: integer("created_at").notNull().default(sql`extract(epoch from now())::integer`),
+  updated_at: integer("updated_at").notNull().default(sql`extract(epoch from now())::integer`),
+});
+
+// RETENTION POLICY: NO TTL, NO deletion sweep, EVER. Long-term companion-memory
+// substrate. Deletion is a manual operator action only, never code.
+export const coomanderMessageLog = pgTable("coomander_message_log", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  direction: text("direction").notNull(),
+  telegram_update_id: integer("telegram_update_id"),
+  text: text("text").notNull(),
+  tool_call_json: text("tool_call_json"),
+  persona_mode: text("persona_mode").notNull().default("light_companion"),
+  created_at: integer("created_at").notNull().default(sql`extract(epoch from now())::integer`),
+}, (table) => [
+  index("idx_coomander_message_log_user_created").on(table.user_id, table.created_at),
+]);
+
+export const coomanderUsage = pgTable("coomander_usage", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  slot_or_inbound: text("slot_or_inbound").notNull(),
+  input_tokens: integer("input_tokens").notNull().default(0),
+  output_tokens: integer("output_tokens").notNull().default(0),
+  model: text("model").notNull(),
+  created_at: integer("created_at").notNull().default(sql`extract(epoch from now())::integer`),
+}, (table) => [
+  index("idx_coomander_usage_user_id").on(table.user_id),
+]);
+
+export const coomanderDayState = pgTable("coomander_day_state", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  date: text("date").notNull(),
+  morning_ping_sent_at: integer("morning_ping_sent_at"),
+  midday_ping_sent_at: integer("midday_ping_sent_at"),
+  evening_recap_at: integer("evening_recap_at"),
+  day_quality: text("day_quality"),
+}, (table) => [
+  uniqueIndex("coomander_day_state_user_date_unique").on(table.user_id, table.date),
+  index("idx_coomander_day_state_user_id").on(table.user_id),
+]);
+
+export const coomanderDedup = pgTable("coomander_dedup", {
+  telegram_update_id: integer("telegram_update_id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  processed_at: integer("processed_at").notNull().default(sql`extract(epoch from now())::integer`),
+});

--- a/node/lib/schema.sqlite.ts
+++ b/node/lib/schema.sqlite.ts
@@ -29,6 +29,9 @@ export const user = sqliteTable("user", {
   subscriptionStatus: text("subscriptionStatus").default("inactive"),
   isAdmin: integer("isAdmin").notNull().default(0),
   disabled: integer("disabled").notNull().default(0),
+  // Coomander (#151): Telegram destination + opt-in flag for the ops agent.
+  telegramChatId: text("telegramChatId"),
+  coomanderEnabled: integer("coomanderEnabled").notNull().default(0),
 });
 
 export const session = sqliteTable("session", {
@@ -449,3 +452,83 @@ export type NewDemographic = typeof demographics.$inferInsert;
 
 export type ContentInsight = typeof contentInsights.$inferSelect;
 export type NewContentInsight = typeof contentInsights.$inferInsert;
+
+// ─── Coomander — AI ops agent infrastructure (#151) ──────────────────────────
+// Pure infra port from ~/Code/geology. Domain model is #152. All tables are
+// user_id-scoped. See migrations/016_coomander_infra.sql and
+// docs/strategy/coomander-direction.md.
+
+export const coomanderSettings = sqliteTable("coomander_settings", {
+  user_id: text("user_id").primaryKey().references(() => user.id, { onDelete: "cascade" }),
+  // tight (default) | moderate | light — see coomander-direction.md § Nag frequency
+  nag_frequency: text("nag_frequency").notNull().default("tight"),
+  // light_companion (default) | full_companion | operational
+  persona_mode: text("persona_mode").notNull().default("light_companion"),
+  ping_times_json: text("ping_times_json"),
+  companion_consent_at: integer("companion_consent_at"),
+  created_at: integer("created_at").notNull().default(sql`(unixepoch())`),
+  updated_at: integer("updated_at").notNull().default(sql`(unixepoch())`),
+});
+
+// RETENTION POLICY: NO TTL, NO deletion sweep, EVER. This is the long-term
+// companion-memory substrate — full-companion persona depends on an indefinite
+// log of the creator's conversational history. Any deletion is a manual
+// operator action (user request / GDPR), never code.
+export const coomanderMessageLog = sqliteTable("coomander_message_log", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  direction: text("direction").notNull(), // 'inbound' | 'outbound'
+  telegram_update_id: integer("telegram_update_id"),
+  text: text("text").notNull(),
+  tool_call_json: text("tool_call_json"),
+  persona_mode: text("persona_mode").notNull().default("light_companion"),
+  created_at: integer("created_at").notNull().default(sql`(unixepoch())`),
+}, (table) => [
+  index("idx_coomander_message_log_user_created").on(table.user_id, table.created_at),
+]);
+
+export const coomanderUsage = sqliteTable("coomander_usage", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  slot_or_inbound: text("slot_or_inbound").notNull(),
+  input_tokens: integer("input_tokens").notNull().default(0),
+  output_tokens: integer("output_tokens").notNull().default(0),
+  model: text("model").notNull(),
+  created_at: integer("created_at").notNull().default(sql`(unixepoch())`),
+}, (table) => [
+  index("idx_coomander_usage_user_id").on(table.user_id),
+]);
+
+export const coomanderDayState = sqliteTable("coomander_day_state", {
+  id: text("id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  date: text("date").notNull(), // YYYY-MM-DD in the user's local tz
+  morning_ping_sent_at: integer("morning_ping_sent_at"),
+  midday_ping_sent_at: integer("midday_ping_sent_at"),
+  evening_recap_at: integer("evening_recap_at"),
+  day_quality: text("day_quality"), // 'good' | 'bad' | null
+}, (table) => [
+  uniqueIndex("coomander_day_state_user_date_unique").on(table.user_id, table.date),
+  index("idx_coomander_day_state_user_id").on(table.user_id),
+]);
+
+export const coomanderDedup = sqliteTable("coomander_dedup", {
+  telegram_update_id: integer("telegram_update_id").primaryKey(),
+  user_id: text("user_id").notNull().references(() => user.id, { onDelete: "cascade" }),
+  processed_at: integer("processed_at").notNull().default(sql`(unixepoch())`),
+});
+
+export type CoomanderSettings = typeof coomanderSettings.$inferSelect;
+export type NewCoomanderSettings = typeof coomanderSettings.$inferInsert;
+
+export type CoomanderMessageLog = typeof coomanderMessageLog.$inferSelect;
+export type NewCoomanderMessageLog = typeof coomanderMessageLog.$inferInsert;
+
+export type CoomanderUsage = typeof coomanderUsage.$inferSelect;
+export type NewCoomanderUsage = typeof coomanderUsage.$inferInsert;
+
+export type CoomanderDayState = typeof coomanderDayState.$inferSelect;
+export type NewCoomanderDayState = typeof coomanderDayState.$inferInsert;
+
+export type CoomanderDedup = typeof coomanderDedup.$inferSelect;
+export type NewCoomanderDedup = typeof coomanderDedup.$inferInsert;

--- a/node/lib/schema.ts
+++ b/node/lib/schema.ts
@@ -48,6 +48,11 @@ export const postInsights = mod.postInsights;
 export const accountSnapshots = mod.accountSnapshots;
 export const demographics = mod.demographics;
 export const contentInsights = mod.contentInsights;
+export const coomanderSettings = mod.coomanderSettings;
+export const coomanderMessageLog = mod.coomanderMessageLog;
+export const coomanderUsage = mod.coomanderUsage;
+export const coomanderDayState = mod.coomanderDayState;
+export const coomanderDedup = mod.coomanderDedup;
 
 export type {
   Platform,
@@ -64,4 +69,14 @@ export type {
   NewDemographic,
   ContentInsight,
   NewContentInsight,
+  CoomanderSettings,
+  NewCoomanderSettings,
+  CoomanderMessageLog,
+  NewCoomanderMessageLog,
+  CoomanderUsage,
+  NewCoomanderUsage,
+  CoomanderDayState,
+  NewCoomanderDayState,
+  CoomanderDedup,
+  NewCoomanderDedup,
 } from "./schema.sqlite";

--- a/node/migrations/016_coomander_infra.sql
+++ b/node/migrations/016_coomander_infra.sql
@@ -1,0 +1,97 @@
+-- Coomander agent infrastructure (Ops A, #151 — milestone 1 "says hello").
+--
+-- Pure infrastructure port from ~/Code/geology. No domain logic here; the ops
+-- domain model (cadence, procurement, content states) lands in #152.
+--
+-- All tables are user_id-scoped with ON DELETE CASCADE so a deleted user takes
+-- their Coomander data with them.
+--
+-- Applied to dev SQLite via `npm run db:migrate` (lib/migrate.ts) and to prod
+-- Cloudflare D1 via `wrangler d1 migrations apply` (migrations_dir = "migrations").
+
+-- ── User-table extensions ───────────────────────────────────────────────────
+-- camelCase to match the existing user-table convention (emailVerified, isAdmin,
+-- stripeCustomerId). The `user` table is bootstrapped by Better Auth and is not
+-- managed by drizzle-kit; these two app columns are added by hand here.
+ALTER TABLE user ADD COLUMN telegramChatId TEXT;
+ALTER TABLE user ADD COLUMN coomanderEnabled INTEGER NOT NULL DEFAULT 0;
+
+-- ── coomander_settings ──────────────────────────────────────────────────────
+-- Per-user agent configuration. One row per ops-enabled user.
+--   nag_frequency: tight (default) | moderate | light  (see coomander-direction.md § Nag frequency)
+--   persona_mode:  light_companion (default) | full_companion | operational
+--   ping_times_json: optional per-user cron-time overrides (V2 polish)
+--   companion_consent_at: unix seconds — set when the user opts into full_companion (if/when it ships)
+CREATE TABLE IF NOT EXISTS coomander_settings (
+  user_id TEXT PRIMARY KEY,
+  nag_frequency TEXT NOT NULL DEFAULT 'tight',
+  persona_mode TEXT NOT NULL DEFAULT 'light_companion',
+  ping_times_json TEXT,
+  companion_consent_at INTEGER,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+
+-- ── coomander_message_log ───────────────────────────────────────────────────
+-- The long-term companion-memory substrate. RETENTION POLICY: NO TTL, NO
+-- deletion sweep, EVER. Full-companion persona (later) depends on having an
+-- indefinite log of the creator's conversational history. Captures BOTH
+-- directions, the structured tool-call (when an inbound classifies into a domain
+-- action), and the persona mode in effect at send time. If we ever must delete
+-- (explicit user request / GDPR), that is a manual operator action — never code.
+CREATE TABLE IF NOT EXISTS coomander_message_log (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  direction TEXT NOT NULL,                 -- 'inbound' | 'outbound'
+  telegram_update_id INTEGER,              -- nullable; set for inbound updates
+  text TEXT NOT NULL,
+  tool_call_json TEXT,                     -- nullable; classifier output for inbound
+  persona_mode TEXT NOT NULL DEFAULT 'light_companion',
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_coomander_message_log_user_created
+  ON coomander_message_log(user_id, created_at);
+
+-- ── coomander_usage ─────────────────────────────────────────────────────────
+-- Per-user Anthropic token usage. Write-path is exercised once the persona
+-- prompt + classifier land; the table exists now so the schema is stable.
+CREATE TABLE IF NOT EXISTS coomander_usage (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  slot_or_inbound TEXT NOT NULL,           -- 'morning' | 'midday' | 'evening' | 'check' | 'inbound'
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  model TEXT NOT NULL,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_coomander_usage_user_id ON coomander_usage(user_id);
+
+-- ── coomander_day_state ─────────────────────────────────────────────────────
+-- Per-user, per-day ping bookkeeping. planPing decision logic (milestone 2+)
+-- reads/stamps these so a slot is not re-fired on every cron tick.
+CREATE TABLE IF NOT EXISTS coomander_day_state (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  date TEXT NOT NULL,                      -- YYYY-MM-DD in the user's local tz
+  morning_ping_sent_at INTEGER,
+  midday_ping_sent_at INTEGER,
+  evening_recap_at INTEGER,
+  day_quality TEXT,                        -- 'good' | 'bad' | NULL
+  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS coomander_day_state_user_date_unique
+  ON coomander_day_state(user_id, date);
+CREATE INDEX IF NOT EXISTS idx_coomander_day_state_user_id ON coomander_day_state(user_id);
+
+-- ── coomander_dedup ─────────────────────────────────────────────────────────
+-- Inbound Telegram update_id de-duplication (at-least-once delivery). Write-path
+-- lands with the inbound webhook in milestone 2; the table exists now.
+CREATE TABLE IF NOT EXISTS coomander_dedup (
+  telegram_update_id INTEGER PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  processed_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+);

--- a/node/scripts/seed.ts
+++ b/node/scripts/seed.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env npx tsx
 /**
- * Seed the database with sample development data.
- * Usage: npx tsx scripts/seed.ts
+ * Seed development data.
+ * Usage: npx tsx scripts/seed.ts   (or: npm run db:seed)
  *
- * Note: This requires a user to exist in the database (created via Better Auth).
- * Run the app, sign up a test user, then run this script.
+ * Milestone 1 (#151): enable Coomander for the dev admin user so the cron /
+ * `POST /api/coomander/run` end-to-end test has a recipient.
+ *
+ * Prereq: a user must exist. The dev admin (admin@example.com) is auto-created
+ * on first app boot (lib/db.ts seedDefaultAdmin). If you see "No users found",
+ * boot the app once (docker compose up) then re-run this script.
  */
 
 import Database from "better-sqlite3";
@@ -19,40 +23,37 @@ const db = new Database(dbPath);
 db.pragma("journal_mode = WAL");
 db.pragma("foreign_keys = ON");
 
-// Find the first user in the database
-const user = db.prepare("SELECT id, email FROM user LIMIT 1").get() as
-  | { id: string; email: string }
-  | undefined;
+// Prefer the dev admin; fall back to the first user.
+const user =
+  (db.prepare("SELECT id, email FROM user WHERE email = 'admin@example.com'").get() as
+    | { id: string; email: string }
+    | undefined) ??
+  (db.prepare("SELECT id, email FROM user LIMIT 1").get() as
+    | { id: string; email: string }
+    | undefined);
 
 if (!user) {
-  console.error("No users found. Sign up a test user first, then run this script.");
+  console.error("No users found. Boot the app once (docker compose up) to create admin@example.com, then re-run.");
   process.exit(1);
 }
 
-console.log(`Seeding data for user: ${user.email} (${user.id})`);
+console.log(`Seeding Coomander dev data for: ${user.email} (${user.id})`);
 
-function generateId() {
-  return Math.random().toString(36).slice(2) + Date.now().toString(36);
-}
+// Mark's Telegram chat_id (docs/strategy/next-session-brief.md §3.3) + opt-in.
+const MADDIE_TELEGRAM_CHAT_ID = "5393209237";
 
-const sampleItems = [
-  { name: "Getting Started Guide", description: "Read the docs and set up your environment" },
-  { name: "Authentication System", description: "Email/password, OAuth, and MFA are all ready" },
-  { name: "Payment Integration", description: "Stripe checkout, portal, and webhooks configured" },
-  { name: "Email Templates", description: "Welcome, verification, and password reset emails" },
-  { name: "Database Schema", description: "SQLite with Better Auth tables and items table" },
-];
+db.prepare(
+  "UPDATE user SET telegramChatId = ?, coomanderEnabled = 1 WHERE id = ?"
+).run(MADDIE_TELEGRAM_CHAT_ID, user.id);
 
-const insertItem = db.prepare(
-  "INSERT OR IGNORE INTO items (id, user_id, name, description) VALUES (?, ?, ?, ?)"
-);
+// Default settings row (tight nag, light-companion persona) — idempotent.
+const now = Math.floor(Date.now() / 1000);
+db.prepare(
+  `INSERT OR IGNORE INTO coomander_settings
+     (user_id, nag_frequency, persona_mode, created_at, updated_at)
+   VALUES (?, 'tight', 'light_companion', ?, ?)`
+).run(user.id, now, now);
 
-let inserted = 0;
-for (const item of sampleItems) {
-  const result = insertItem.run(generateId(), user.id, item.name, item.description);
-  if (result.changes > 0) inserted++;
-}
-
-console.log(`✓ Inserted ${inserted} sample item(s).`);
+console.log(`✓ Coomander enabled (telegramChatId=${MADDIE_TELEGRAM_CHAT_ID}, nag=tight, persona=light_companion).`);
 
 db.close();

--- a/node/tests/coomander-agent.test.ts
+++ b/node/tests/coomander-agent.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { planPing, PRESET_SLOTS } from "@/lib/coomander/agent";
+
+type Slot = "morning" | "midday" | "check" | "evening";
+type NagFrequency = "tight" | "moderate" | "light";
+
+const ALL_SLOTS: Slot[] = ["morning", "midday", "check", "evening"];
+const ALL_PRESETS: NagFrequency[] = ["tight", "moderate", "light"];
+
+// Spec'd allowed-slot sets, declared here independently of the implementation.
+const ALLOWED: Record<NagFrequency, Slot[]> = {
+  tight: ["morning", "midday", "check", "evening"],
+  moderate: ["morning", "midday", "evening"],
+  light: ["morning", "evening"],
+};
+
+describe("PRESET_SLOTS", () => {
+  it("tight contains all four slots in order", () => {
+    expect(PRESET_SLOTS.tight).toEqual(["morning", "midday", "check", "evening"]);
+  });
+
+  it("moderate drops the check slot", () => {
+    expect(PRESET_SLOTS.moderate).toEqual(["morning", "midday", "evening"]);
+  });
+
+  it("light keeps only morning and evening", () => {
+    expect(PRESET_SLOTS.light).toEqual(["morning", "evening"]);
+  });
+});
+
+describe("planPing — preset gating (no day quality)", () => {
+  for (const preset of ALL_PRESETS) {
+    for (const slot of ALL_SLOTS) {
+      const allowed = ALLOWED[preset].includes(slot);
+      it(`${preset} preset, ${slot} slot → send=${allowed}`, () => {
+        const result = planPing({ slot, nagFrequency: preset });
+        expect(result.send).toBe(allowed);
+      });
+    }
+  }
+
+  it("a slot not in the preset includes a reason mentioning the preset", () => {
+    // light preset excludes midday + check
+    const midday = planPing({ slot: "midday", nagFrequency: "light" });
+    expect(midday.send).toBe(false);
+    expect(midday.reason).toBeTruthy();
+    expect(midday.reason!.toLowerCase()).toContain("preset");
+
+    const check = planPing({ slot: "check", nagFrequency: "light" });
+    expect(check.send).toBe(false);
+    expect(check.reason).toBeTruthy();
+    expect(check.reason!.toLowerCase()).toContain("preset");
+  });
+
+  it("light preset: morning and evening fire, midday and check are suppressed", () => {
+    expect(planPing({ slot: "morning", nagFrequency: "light" }).send).toBe(true);
+    expect(planPing({ slot: "evening", nagFrequency: "light" }).send).toBe(true);
+    expect(planPing({ slot: "midday", nagFrequency: "light" }).send).toBe(false);
+    expect(planPing({ slot: "check", nagFrequency: "light" }).send).toBe(false);
+  });
+
+  it("moderate preset: only the check slot is suppressed", () => {
+    expect(planPing({ slot: "morning", nagFrequency: "moderate" }).send).toBe(true);
+    expect(planPing({ slot: "midday", nagFrequency: "moderate" }).send).toBe(true);
+    expect(planPing({ slot: "evening", nagFrequency: "moderate" }).send).toBe(true);
+    expect(planPing({ slot: "check", nagFrequency: "moderate" }).send).toBe(false);
+  });
+
+  it("tight preset: every slot fires", () => {
+    for (const slot of ALL_SLOTS) {
+      expect(planPing({ slot, nagFrequency: "tight" }).send).toBe(true);
+    }
+  });
+});
+
+describe("planPing — bad-day suppression", () => {
+  it("tight: bad day suppresses midday and check, but never morning/evening", () => {
+    expect(planPing({ slot: "midday", nagFrequency: "tight", dayQuality: "bad" }).send).toBe(false);
+    expect(planPing({ slot: "check", nagFrequency: "tight", dayQuality: "bad" }).send).toBe(false);
+    expect(planPing({ slot: "morning", nagFrequency: "tight", dayQuality: "bad" }).send).toBe(true);
+    expect(planPing({ slot: "evening", nagFrequency: "tight", dayQuality: "bad" }).send).toBe(true);
+  });
+
+  it("moderate: bad day suppresses midday (check already gated by preset)", () => {
+    expect(planPing({ slot: "midday", nagFrequency: "moderate", dayQuality: "bad" }).send).toBe(false);
+    expect(planPing({ slot: "morning", nagFrequency: "moderate", dayQuality: "bad" }).send).toBe(true);
+    expect(planPing({ slot: "evening", nagFrequency: "moderate", dayQuality: "bad" }).send).toBe(true);
+  });
+
+  it("light: bad day never affects the only allowed slots (morning/evening)", () => {
+    expect(planPing({ slot: "morning", nagFrequency: "light", dayQuality: "bad" }).send).toBe(true);
+    expect(planPing({ slot: "evening", nagFrequency: "light", dayQuality: "bad" }).send).toBe(true);
+  });
+
+  it("bad-day suppression reason mentions the bad day", () => {
+    const result = planPing({ slot: "midday", nagFrequency: "tight", dayQuality: "bad" });
+    expect(result.send).toBe(false);
+    expect(result.reason).toBeTruthy();
+    expect(result.reason!.toLowerCase()).toContain("bad");
+  });
+
+  it("dayQuality 'good' never suppresses any allowed slot", () => {
+    for (const preset of ALL_PRESETS) {
+      for (const slot of ALLOWED[preset]) {
+        expect(
+          planPing({ slot, nagFrequency: preset, dayQuality: "good" }).send,
+          `${preset}/${slot} with good day`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("dayQuality null never suppresses any allowed slot", () => {
+    for (const preset of ALL_PRESETS) {
+      for (const slot of ALLOWED[preset]) {
+        expect(
+          planPing({ slot, nagFrequency: preset, dayQuality: null }).send,
+          `${preset}/${slot} with null day`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("dayQuality undefined (omitted) never suppresses any allowed slot", () => {
+    for (const preset of ALL_PRESETS) {
+      for (const slot of ALLOWED[preset]) {
+        expect(
+          planPing({ slot, nagFrequency: preset }).send,
+          `${preset}/${slot} with undefined day`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/node/tests/coomander-dedup.test.ts
+++ b/node/tests/coomander-dedup.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { claimUpdate } from "@/lib/coomander/telegramDedup";
+import { getRawDb } from "@/lib/db";
+// Importing the db helper bootstraps the Better Auth `user` table schema.
+import "./helpers/db";
+
+let userIdCounter = 0;
+function seedUser(): string {
+  const id = `coomander-dedup-user-${Date.now()}-${userIdCounter++}`;
+  const email = `${id}@test.com`;
+  const now = Math.floor(Date.now() / 1000);
+  getRawDb()
+    .prepare(
+      "INSERT INTO user (id, email, emailVerified, createdAt, updatedAt, isAdmin, disabled, coomanderEnabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(id, email, 1, now, now, 0, 0, 1);
+  return id;
+}
+
+// Use a fresh, monotonically-increasing block of update IDs per test so cases
+// never collide on the coomander_dedup primary key across the shared test.db.
+let updateIdBase = 900_000;
+function nextUpdateId(): number {
+  return updateIdBase++;
+}
+
+describe("claimUpdate (telegram at-least-once dedup)", () => {
+  let userId: string;
+
+  beforeAll(() => {
+    userId = seedUser();
+  });
+
+  it("returns true the first time a new updateId is claimed", async () => {
+    const updateId = nextUpdateId();
+    await expect(claimUpdate(updateId, userId)).resolves.toBe(true);
+  });
+
+  it("returns false on a second claim of the same updateId (idempotent)", async () => {
+    const updateId = nextUpdateId();
+    const first = await claimUpdate(updateId, userId);
+    const second = await claimUpdate(updateId, userId);
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  it("returns true for a different updateId", async () => {
+    const idA = nextUpdateId();
+    const idB = nextUpdateId();
+    expect(await claimUpdate(idA, userId)).toBe(true);
+    expect(await claimUpdate(idB, userId)).toBe(true);
+  });
+
+  it("records the claimed update in the coomander_dedup table", async () => {
+    const updateId = nextUpdateId();
+    await claimUpdate(updateId, userId);
+    const row = getRawDb()
+      .prepare(
+        "SELECT telegram_update_id, user_id FROM coomander_dedup WHERE telegram_update_id = ?",
+      )
+      .get(updateId) as { telegram_update_id: number; user_id: string } | undefined;
+    expect(row).toBeTruthy();
+    expect(row!.telegram_update_id).toBe(updateId);
+    expect(row!.user_id).toBe(userId);
+  });
+
+  it("a repeated claim does not insert a duplicate row", async () => {
+    const updateId = nextUpdateId();
+    await claimUpdate(updateId, userId);
+    await claimUpdate(updateId, userId);
+    const { c } = getRawDb()
+      .prepare(
+        "SELECT COUNT(*) as c FROM coomander_dedup WHERE telegram_update_id = ?",
+      )
+      .get(updateId) as { c: number };
+    expect(c).toBe(1);
+  });
+});

--- a/node/tests/coomander-messages.test.ts
+++ b/node/tests/coomander-messages.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  appendMessage,
+  listMessages,
+  messagesSince,
+} from "@/lib/coomander/coomanderMessages";
+import { getRawDb } from "@/lib/db";
+// Importing the db helper bootstraps the Better Auth `user` table schema.
+import "./helpers/db";
+
+let userIdCounter = 0;
+function seedUser(): string {
+  const id = `coomander-msg-user-${Date.now()}-${userIdCounter++}`;
+  const email = `${id}@test.com`;
+  const now = Math.floor(Date.now() / 1000);
+  getRawDb()
+    .prepare(
+      "INSERT INTO user (id, email, emailVerified, createdAt, updatedAt, isAdmin, disabled, coomanderEnabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(id, email, 1, now, now, 0, 0, 1);
+  return id;
+}
+
+describe("coomanderMessages — indefinite-retention message log (#151)", () => {
+  it("retains all 100 appended messages — no TTL, no sweep (default-limit case)", async () => {
+    const userId = seedUser();
+    for (let i = 0; i < 100; i++) {
+      await appendMessage(userId, "inbound", `message ${i}`);
+    }
+    // Default limit is 100; pass it explicitly to be unambiguous.
+    const rows = await listMessages(userId, 100);
+    expect(rows.length).toBe(100);
+  });
+
+  it("retains well over the default limit when an explicit larger limit is given", async () => {
+    const userId = seedUser();
+    const total = 150;
+    for (let i = 0; i < total; i++) {
+      await appendMessage(userId, "inbound", `message ${i}`);
+    }
+    // Confirm none were swept/deleted: the underlying log still holds all rows.
+    const rows = await listMessages(userId, total);
+    expect(rows.length).toBe(total);
+  });
+
+  it("persists both inbound and outbound directions", async () => {
+    const userId = seedUser();
+    await appendMessage(userId, "inbound", "user said hi");
+    await appendMessage(userId, "outbound", "assistant replied");
+    await appendMessage(userId, "inbound", "user said bye");
+
+    const rows = await listMessages(userId, 100);
+    const directions = new Set(rows.map((r) => r.direction));
+    expect(directions.has("inbound")).toBe(true);
+    expect(directions.has("outbound")).toBe(true);
+  });
+
+  it("round-trips persona_mode", async () => {
+    const userId = seedUser();
+    await appendMessage(userId, "outbound", "operational reply", {
+      personaMode: "operational",
+    });
+
+    const rows = await listMessages(userId, 100);
+    const row = rows.find((r) => r.text === "operational reply");
+    expect(row).toBeTruthy();
+    expect(row!.personaMode).toBe("operational");
+  });
+
+  it("round-trips toolCall as parsed JSON", async () => {
+    const userId = seedUser();
+    const toolCall = {
+      toolName: "need_clarification",
+      input: { reply: "hi" },
+    };
+    await appendMessage(userId, "inbound", "needs clarification", { toolCall });
+
+    const rows = await listMessages(userId, 100);
+    const row = rows.find((r) => r.text === "needs clarification");
+    expect(row).toBeTruthy();
+    expect(row!.toolCall).toEqual(toolCall);
+  });
+
+  it("listMessages returns rows oldest-first", async () => {
+    const userId = seedUser();
+    const texts = ["first", "second", "third", "fourth"];
+    for (const t of texts) {
+      await appendMessage(userId, "inbound", t);
+    }
+
+    const rows = await listMessages(userId, 100);
+    expect(rows.map((r) => r.text)).toEqual(texts);
+  });
+
+  it("messagesSince returns only rows after the cursor, oldest-first", async () => {
+    const userId = seedUser();
+    await appendMessage(userId, "inbound", "old message");
+    // Cursor strictly after the first message's created_at second.
+    const cursor = Math.floor(Date.now() / 1000) + 5;
+    // Force later rows to have a created_at greater than the cursor by waiting
+    // past the cursor boundary is impractical in a unit test; instead assert the
+    // ordering/filter contract on whatever rows qualify.
+    const rows = await messagesSince(userId, 0);
+    // since 0 → everything for this user, oldest-first
+    const sorted = [...rows].sort((a, b) => a.createdAt - b.createdAt);
+    expect(rows.map((r) => r.id)).toEqual(sorted.map((r) => r.id));
+    // And a future cursor returns nothing.
+    const none = await messagesSince(userId, cursor);
+    expect(none.length).toBe(0);
+  });
+});

--- a/node/tests/coomander-settings.test.ts
+++ b/node/tests/coomander-settings.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  pickNagFrequency,
+  pickPersonaMode,
+  isValidNagFrequency,
+  isValidPersonaMode,
+  DEFAULT_NAG_FREQUENCY,
+  DEFAULT_PERSONA_MODE,
+} from "@/lib/coomander/settings";
+
+describe("settings defaults", () => {
+  it("DEFAULT_NAG_FREQUENCY is 'tight'", () => {
+    expect(DEFAULT_NAG_FREQUENCY).toBe("tight");
+  });
+
+  it("DEFAULT_PERSONA_MODE is 'light_companion'", () => {
+    expect(DEFAULT_PERSONA_MODE).toBe("light_companion");
+  });
+});
+
+describe("pickNagFrequency", () => {
+  it("returns a valid value verbatim", () => {
+    expect(pickNagFrequency({ nag_frequency: "tight" })).toBe("tight");
+    expect(pickNagFrequency({ nag_frequency: "moderate" })).toBe("moderate");
+    expect(pickNagFrequency({ nag_frequency: "light" })).toBe("light");
+  });
+
+  it("falls back to default when row is undefined", () => {
+    expect(pickNagFrequency(undefined)).toBe(DEFAULT_NAG_FREQUENCY);
+  });
+
+  it("falls back to default when field is missing", () => {
+    expect(pickNagFrequency({})).toBe(DEFAULT_NAG_FREQUENCY);
+  });
+
+  it("falls back to default for an empty string", () => {
+    expect(pickNagFrequency({ nag_frequency: "" })).toBe(DEFAULT_NAG_FREQUENCY);
+  });
+
+  it("falls back to default for an arbitrary invalid string", () => {
+    expect(pickNagFrequency({ nag_frequency: "aggressive" })).toBe(DEFAULT_NAG_FREQUENCY);
+  });
+});
+
+describe("pickPersonaMode", () => {
+  it("returns a valid value verbatim", () => {
+    expect(pickPersonaMode({ persona_mode: "light_companion" })).toBe("light_companion");
+    expect(pickPersonaMode({ persona_mode: "full_companion" })).toBe("full_companion");
+    expect(pickPersonaMode({ persona_mode: "operational" })).toBe("operational");
+  });
+
+  it("falls back to default when row is undefined", () => {
+    expect(pickPersonaMode(undefined)).toBe(DEFAULT_PERSONA_MODE);
+  });
+
+  it("falls back to default when field is missing", () => {
+    expect(pickPersonaMode({})).toBe(DEFAULT_PERSONA_MODE);
+  });
+
+  it("falls back to default for an empty string", () => {
+    expect(pickPersonaMode({ persona_mode: "" })).toBe(DEFAULT_PERSONA_MODE);
+  });
+
+  it("falls back to default for an arbitrary invalid string", () => {
+    expect(pickPersonaMode({ persona_mode: "robot" })).toBe(DEFAULT_PERSONA_MODE);
+  });
+});
+
+describe("isValidNagFrequency", () => {
+  it("true for the three valid literals", () => {
+    expect(isValidNagFrequency("tight")).toBe(true);
+    expect(isValidNagFrequency("moderate")).toBe(true);
+    expect(isValidNagFrequency("light")).toBe(true);
+  });
+
+  it("false for invalid inputs", () => {
+    expect(isValidNagFrequency("")).toBe(false);
+    expect(isValidNagFrequency("aggressive")).toBe(false);
+    expect(isValidNagFrequency("TIGHT")).toBe(false);
+    expect(isValidNagFrequency(null)).toBe(false);
+    expect(isValidNagFrequency(undefined)).toBe(false);
+    expect(isValidNagFrequency(1)).toBe(false);
+    expect(isValidNagFrequency(0)).toBe(false);
+  });
+});
+
+describe("isValidPersonaMode", () => {
+  it("true for the three valid literals", () => {
+    expect(isValidPersonaMode("light_companion")).toBe(true);
+    expect(isValidPersonaMode("full_companion")).toBe(true);
+    expect(isValidPersonaMode("operational")).toBe(true);
+  });
+
+  it("false for invalid inputs", () => {
+    expect(isValidPersonaMode("")).toBe(false);
+    expect(isValidPersonaMode("robot")).toBe(false);
+    expect(isValidPersonaMode("light")).toBe(false);
+    expect(isValidPersonaMode(null)).toBe(false);
+    expect(isValidPersonaMode(undefined)).toBe(false);
+    expect(isValidPersonaMode(42)).toBe(false);
+    expect(isValidPersonaMode(0)).toBe(false);
+  });
+});

--- a/node/wrangler.toml
+++ b/node/wrangler.toml
@@ -4,7 +4,9 @@
 # with values from `wrangler d1 create` / `wrangler r2 bucket create`.
 
 name = "maddiehq"
-main = ".open-next/worker.js"
+# Custom Worker entrypoint (#151): wraps .open-next/worker.js to add the
+# Coomander cron `scheduled()` handler. See custom-worker.ts.
+main = "custom-worker.ts"
 
 # Custom domain — Cloudflare provisions the cert on deploy.
 # Requires oqodo.com to be on this Cloudflare account.
@@ -20,6 +22,19 @@ compatibility_flags = ["nodejs_compat"]
 
 # Static assets emitted by `opennextjs-cloudflare build`.
 assets = { directory = ".open-next/assets", binding = "ASSETS" }
+
+# ── Coomander cron (#151) ──────────────────────────────────────────────────
+# IMPORTANT (§9.4 gotcha): this [triggers] table — like every other [table]
+# header below — MUST stay BELOW all top-level scalars (name, main,
+# compatibility_*, assets, routes). A table header placed above them silently
+# absorbs the scalars that follow it. Validate with `wrangler deploy --dry-run`.
+#
+# MILESTONE 1: a single fast test cron (every 10 min) for rapid iteration. The
+# scheduled() handler in custom-worker.ts maps the trigger to a POST
+# /api/coomander/run. Lower to the real tight-preset cadence (morning/midday/
+# evening, UTC-translated) once planPing decision logic lands.
+[triggers]
+crons = ["*/10 * * * *"]
 
 # Plain env vars (non-secret). Secrets go through `wrangler secret put`.
 [vars]

--- a/node/wrangler.toml
+++ b/node/wrangler.toml
@@ -29,12 +29,14 @@ assets = { directory = ".open-next/assets", binding = "ASSETS" }
 # compatibility_*, assets, routes). A table header placed above them silently
 # absorbs the scalars that follow it. Validate with `wrangler deploy --dry-run`.
 #
-# MILESTONE 1: a single fast test cron (every 10 min) for rapid iteration. The
-# scheduled() handler in custom-worker.ts maps the trigger to a POST
-# /api/coomander/run. Lower to the real tight-preset cadence (morning/midday/
-# evening, UTC-translated) once planPing decision logic lands.
+# Tight-preset cadence (UTC). custom-worker.ts maps each cron expression to a
+# slot; the run route fans out to opted-in users and applies each user's nag
+# preset (planPing) internally. Times are the tight-preset local intent for US
+# Central translated to UTC (morning ~07:00, midday ~13:00, check ~16:00,
+# evening ~20:00 CT); they drift ~1h across DST until per-user local scheduling
+# lands. Keep in sync with custom-worker.ts CRON_SLOT and scheduling.ts.
 [triggers]
-crons = ["*/10 * * * *"]
+crons = ["0 12 * * *", "0 18 * * *", "0 21 * * *", "0 1 * * *"]
 
 # Plain env vars (non-secret). Secrets go through `wrangler secret put`.
 [vars]


### PR DESCRIPTION
## Coomander — full agent infrastructure (#151)

Complete two-way Coomander ops-agent infrastructure (epic #150 / infra #151). Built across this session in two slices (outbound, then inbound/presets) and now landed together at owner request.

**Canonical direction:** `docs/strategy/coomander-direction.md` · **Comms posture:** `docs/strategy/communication-policy.md`

### What's in this PR
- **Schema** (`migration 016`, all dialects + barrel): `coomander_settings`, `coomander_message_log` (**no-TTL** companion-memory substrate), `coomander_usage`, `coomander_day_state`, `coomander_dedup`; `user.telegramChatId` + `user.coomanderEnabled`.
- **`lib/coomander/`** — full 9-file port from geology, domain logic stripped (domain is #152): `telegram`, `usage`, `settings` (nag presets + persona modes + recipient resolution), `agentPrompts` (light-companion persona, data-grounded praise, OF comms boundaries, PLACEHOLDER block for #153), `scheduling` (cron→slot, day_state), `agent` (pure `planPing` + `runAgentPing`), `coomanderMessages`, `coomanderChat`, `telegramDedup`, `inbound` (Anthropic tool-use classifier with placeholder `need_clarification` tool).
- **API** — `/api/coomander/run` (secret-gated cron fan-out via planPing), `/api/coomander/webhook` (secret + dedup + classify + persist both directions), `/api/coomander/settings` (GET/PATCH nag preset + persona, DB-backed).
- **Worker/cron** — `custom-worker.ts` maps `event.cron`→slot; `wrangler.toml` tight-preset crons (morning/midday/check/evening UTC).
- **Env** — `MADDIE_TELEGRAM_BOT_TOKEN`, `COOMANDER_RUN_SECRET`, `MADDIE_TELEGRAM_WEBHOOK_SECRET`, `COOMANDER_AGENT_MODEL`, `TS_*` documented in `.env.example`.
- **Tests** (written by separate subagents against the spec, per convention): `planPing` (26), settings pickers (16), dedup idempotency (5), message-log retention (7).

### Verified
- `npm run db:migrate` clean · `npm run typecheck` clean · `npx wrangler deploy --dry-run` validates worker + cron TOML · `npm run test` → **318 passed, 0 failed**.

### QA
QA: #159 — live Telegram round-trip (outbound ping lands; inbound reply classifies/dedups/persists; light-preset midday silence). Manual E2E against the running dev env, deferred to the owner's full QA round.

**Merge note:** merged into `develop` per owner instruction ("merge as needed, full QA round at the end"), so QA #159 stays open for that round rather than gating this merge.

Closes #151.
