### PR TITLE
feat(coomander): per-user timezone day boundary (#183 Phase 1)

### DIFF
--- a/node/.openapi-gen/manifest.json
+++ b/node/.openapi-gen/manifest.json
@@ -1,125 +1,125 @@
 {
-  "configPath": "/Users/marknutter/Code/coomander/node/openapi-gen.config.json",
-  "outputFile": "/Users/marknutter/Code/coomander/node/public/openapi.json",
+  "configPath": "/Users/marknutter/Code/maddiehq/node/openapi-gen.config.json",
+  "outputFile": "/Users/marknutter/Code/maddiehq/node/public/openapi.json",
   "diagnostics": [
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/analyze/instagram/stream/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/analyze/instagram/stream/route.ts",
       "routePath": "/analyze/instagram/stream"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/analyze/instagram/stream/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/analyze/instagram/stream/route.ts",
       "routePath": "/analyze/instagram/stream"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/coomander/beats/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/coomander/beats/route.ts",
       "routePath": "/coomander/beats"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/coomander/content/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/coomander/content/route.ts",
       "routePath": "/coomander/content"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/coomander/drops/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/coomander/drops/route.ts",
       "routePath": "/coomander/drops"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/coomander/pillars/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/coomander/pillars/route.ts",
       "routePath": "/coomander/pillars"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/coomander/procurement/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/coomander/procurement/route.ts",
       "routePath": "/coomander/procurement"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/platforms/instagram/sync/stream/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/platforms/instagram/sync/stream/route.ts",
       "routePath": "/platforms/instagram/sync/stream"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/platforms/instagram/sync/stream/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/platforms/instagram/sync/stream/route.ts",
       "routePath": "/platforms/instagram/sync/stream"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/waitlist/join/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/waitlist/join/route.ts",
       "routePath": "/waitlist/join"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/waitlist/join/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/waitlist/join/route.ts",
       "routePath": "/waitlist/join"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/waitlist/join/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/waitlist/join/route.ts",
       "routePath": "/waitlist/join"
     },
     {
       "code": "response-inference-unresolved",
       "severity": "warning",
       "message": "Could not fully infer a response schema from a return statement. Add an explicit @response tag to make the output deterministic.",
-      "filePath": "/Users/marknutter/Code/coomander/node/app/api/wiki-search/route.ts",
+      "filePath": "/Users/marknutter/Code/maddiehq/node/app/api/wiki-search/route.ts",
       "routePath": "/wiki-search"
     }
   ],
   "performance": {
-    "prepareTemplateMs": 0.10545799999999872,
-    "loadCustomFragmentsMs": 0.00037500000001955414,
-    "prepareDocumentMs": 0.10583300000001827,
-    "scanRouteFilesMs": 3.701833000000022,
-    "deriveRoutePathMs": 0.28478400000005877,
-    "filterRouteCandidatesMs": 0.23504800000142723,
-    "sourcePrecheckMs": 6.362667000001295,
-    "readRouteFilesMs": 5.951795000002733,
-    "parseRouteFilesMs": 33.04824899999829,
-    "analyzeRouteFilesMs": 28.518205999999964,
-    "typescriptResponseInferenceMs": 6813.3222510000005,
-    "processRouteFilesMs": 6875.241834,
-    "registerRouteMs": 2.424121000004277,
+    "prepareTemplateMs": 0.10329200000001038,
+    "loadCustomFragmentsMs": 0.00033400000006622577,
+    "prepareDocumentMs": 0.1036260000000766,
+    "scanRouteFilesMs": 1.7854169999999385,
+    "deriveRoutePathMs": 0.2786280000016177,
+    "filterRouteCandidatesMs": 0.27170799999964856,
+    "sourcePrecheckMs": 2.5671660000009524,
+    "readRouteFilesMs": 2.1087929999974904,
+    "parseRouteFilesMs": 30.511794000001828,
+    "analyzeRouteFilesMs": 24.60141399999793,
+    "typescriptResponseInferenceMs": 4618.738207,
+    "processRouteFilesMs": 4674.235707000003,
+    "registerRouteMs": 3.0269610000010516,
     "getSchemaContentMs": 0,
     "createRequestParamsMs": 0,
     "createRequestBodyMs": 0,
-    "processResponsesMs": 0.9287929999975404,
+    "processResponsesMs": 1.0251249999963647,
     "createResponseSchemaMs": 0,
-    "buildOperationsMs": 2.515664999998421,
-    "sortAndMergePathsMs": 1.4491669999997612,
-    "buildPathsMs": 1.4491669999997612,
-    "defaultComponentsAndErrorsMs": 0.15883400000075198,
-    "mergeSchemasMs": 0.05333299999983865,
-    "finalizeDocumentMs": 8.13274999999976,
-    "totalMs": 6898.649375,
-    "scanRoutesMs": 6881.4593319999985
+    "buildOperationsMs": 3.107790000001728,
+    "sortAndMergePathsMs": 1.0539580000004207,
+    "buildPathsMs": 1.0539580000004207,
+    "defaultComponentsAndErrorsMs": 0.1319999999996071,
+    "mergeSchemasMs": 0.04604199999994307,
+    "finalizeDocumentMs": 5.79858300000069,
+    "totalMs": 4689.780375,
+    "scanRoutesMs": 4679.128914000004
   }
 }

--- a/node/app/api/coomander/settings/route.ts
+++ b/node/app/api/coomander/settings/route.ts
@@ -21,6 +21,16 @@ import { log } from "@/lib/logger";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+/** True if `tz` is a valid IANA timezone (Intl throws on unknown zones). */
+function isValidTimezone(tz: string): boolean {
+  try {
+    Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function GET(request: Request) {
   try {
     const session = await auth.api.getSession({ headers: request.headers });
@@ -58,6 +68,12 @@ export async function PATCH(request: Request) {
         throw new BadRequestError("pingTimesJson must be a string or null");
       }
       patch.pingTimesJson = body.pingTimesJson as string | null;
+    }
+    if (body.timezone !== undefined) {
+      if (typeof body.timezone !== "string" || !isValidTimezone(body.timezone)) {
+        throw new BadRequestError("timezone must be a valid IANA timezone, e.g. America/Chicago");
+      }
+      patch.timezone = body.timezone;
     }
     // Stamps defaults_banner_dismissed_at — used by onboarding (#173) as the
     // "creator confirmed their starter cadence defaults" signal.

--- a/node/lib/coomander/agent.ts
+++ b/node/lib/coomander/agent.ts
@@ -20,15 +20,17 @@ import { sendTelegram } from "./telegram";
 import { coomanderSystem, slotPrompt, type Slot } from "./agentPrompts";
 import {
   getCoomanderSettings,
+  getTimezone,
+  userToday,
   type NagFrequency,
   type PersonaMode,
 } from "./settings";
-import { getDayState, markSlotSent, todayUTC } from "./scheduling";
+import { getDayState, markSlotSent } from "./scheduling";
 import { appendMessage } from "./coomanderMessages";
 import { logCoomanderUsage } from "./usage";
 import { getTodayModel, type TodayModel } from "./todayModel";
 import { expectedToday } from "./ramp";
-import { daysBetween } from "./consistency";
+import { daysBetween, toDateLocal } from "./consistency";
 import { getDb } from "@/lib/db";
 import { user as userT, coomanderSettings as settingsT } from "@/lib/schema";
 import { eq } from "drizzle-orm";
@@ -100,7 +102,9 @@ export async function daysSinceStart(userId: string, today: string): Promise<num
   const rows = (await db.select({ seeded: settingsT.ops_seeded_at }).from(settingsT).where(eq(settingsT.user_id, userId)).limit(1)) as Array<{ seeded: number | null }>;
   const seeded = rows[0]?.seeded;
   if (!seeded) return Number.MAX_SAFE_INTEGER; // not in ramp
-  const seededDate = new Date(seeded * 1000).toISOString().slice(0, 10);
+  // Seed date in the creator's local tz so the ramp counter aligns with their
+  // local "today" (#183).
+  const seededDate = toDateLocal(seeded, await getTimezone(userId));
   return Math.max(0, daysBetween(seededDate, today));
 }
 
@@ -159,7 +163,7 @@ export async function runAgentPing(userId: string, slot: Slot): Promise<AgentRun
     if (!chatId) return { ok: true, slot, sent: false, skipped: "no telegram chat id" };
 
     const settings = await getCoomanderSettings(userId);
-    const date = todayUTC();
+    const date = await userToday(userId);
     const day = await getDayState(userId, date);
     const plan = planPing({ slot, nagFrequency: settings.nagFrequency, dayQuality: day?.day_quality ?? null });
     if (!plan.send) return { ok: true, slot, sent: false, skipped: plan.reason };

--- a/node/lib/coomander/consistency.ts
+++ b/node/lib/coomander/consistency.ts
@@ -11,6 +11,25 @@ export function toDateUTC(unixSeconds: number): string {
   return new Date(unixSeconds * 1000).toISOString().slice(0, 10);
 }
 
+/**
+ * Per-creator timezone day boundary (#183). All "today"/day-bucketing in the ops
+ * layer is the creator's LOCAL calendar day, not UTC — otherwise a US creator's
+ * day rolls over at ~6-7pm local (UTC midnight) and evening work counts as
+ * tomorrow. Ported from geology's floor.ts: `en-CA` renders YYYY-MM-DD, and
+ * forcing `timeZone` makes it independent of the server's clock.
+ */
+export const DEFAULT_TIMEZONE = process.env.COOMANDER_TIMEZONE || "America/Chicago";
+
+/** Today's date as YYYY-MM-DD in an IANA timezone. */
+export function todayLocal(tz: string = DEFAULT_TIMEZONE, now: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit" }).format(now);
+}
+
+/** Local YYYY-MM-DD (in tz) for a unix-seconds timestamp. */
+export function toDateLocal(unixSeconds: number, tz: string = DEFAULT_TIMEZONE): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: tz, year: "numeric", month: "2-digit", day: "2-digit" }).format(new Date(unixSeconds * 1000));
+}
+
 /** Whole days from a → b (both YYYY-MM-DD). Positive if b is after a. */
 export function daysBetween(a: string, b: string): number {
   const da = Date.parse(a + "T00:00:00Z");

--- a/node/lib/coomander/coomanderChat.ts
+++ b/node/lib/coomander/coomanderChat.ts
@@ -14,12 +14,11 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import { listMessages, appendMessage, type CoomanderMessage } from "./coomanderMessages";
-import { getCoomanderSettings } from "./settings";
+import { getCoomanderSettings, userToday } from "./settings";
 import { coomanderSystem } from "./agentPrompts";
 import { getTodayModel } from "./todayModel";
 import { renderContext, daysSinceStart } from "./agent";
 import { tools, resolveToolUse, executeAction, loadContext } from "./inbound";
-import { todayUTC } from "./scheduling";
 import { logCoomanderUsage } from "./usage";
 
 const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
@@ -99,7 +98,7 @@ export async function handleChatTurn(
   opts: HandleChatTurnOptions = {},
 ): Promise<ChatTurnResult> {
   const settings = await getCoomanderSettings(userId);
-  const date = todayUTC();
+  const date = await userToday(userId);
 
   // Build grounding context: live ops state + recent conversation. We inject the
   // thread into the system prompt (rather than as message turns) to avoid

--- a/node/lib/coomander/homeBrief.ts
+++ b/node/lib/coomander/homeBrief.ts
@@ -14,7 +14,7 @@ import type { TodayModel } from "./todayModel";
 import { getTodayModel } from "./todayModel";
 import { daysSinceStart } from "./agent";
 import { expectedToday, inRamp, RAMP_DAYS } from "./ramp";
-import { todayUTC } from "./scheduling";
+import { userToday } from "./settings";
 
 export interface HomeBeatLine {
   beatId: string;
@@ -132,7 +132,7 @@ function headlineFor(
 }
 
 export async function getHomeBrief(userId: string, date?: string): Promise<HomeBrief> {
-  const d = date ?? todayUTC();
+  const d = date ?? await userToday(userId);
   const [model, daysIn] = await Promise.all([
     getTodayModel(userId, d),
     daysSinceStart(userId, d),

--- a/node/lib/coomander/inbound.ts
+++ b/node/lib/coomander/inbound.ts
@@ -21,9 +21,9 @@ import { listContent, transitionContent, CONTENT_STATES, isValidTransition } fro
 import { logDrop, type DropKind } from "./drops";
 import { updateBeat } from "./beats";
 import { listProcurement, createProcurement, updateProcurement, type ProcurementCategory } from "./procurement";
-import { setDayQuality, todayUTC } from "./scheduling";
+import { setDayQuality } from "./scheduling";
 import { checkWallProhibitions } from "./wallProhibitions";
-import type { PersonaMode } from "./settings";
+import { userToday, type PersonaMode } from "./settings";
 import type { ContentStateValue, CadenceBeat, ContentState, ProcurementItem } from "@/lib/schema";
 
 const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
@@ -297,7 +297,7 @@ export async function executeAction(userId: string, action: ResolvedAction, ctx:
       return { reply: `Added "${created.label}" to your ${action.category === "shoot_prep" ? "shoot prep" : "admin"} list${action.neededBy ? ` (by ${action.neededBy})` : ""}.`, acted: true };
     }
     case "mark_blocker": {
-      await setDayQuality(userId, todayUTC(), "bad");
+      await setDayQuality(userId, await userToday(userId), "bad");
       return { reply: `Got it, marked today as a tough one. I will ease off. (${action.reason})`, acted: true };
     }
     case "adjust_beat": {
@@ -319,6 +319,7 @@ async function classifyMessage(userId: string, text: string, ctx: InboundContext
   // message is persisted only AFTER this runs (see the webhook), so it is not
   // duplicated here. Parity with coomanderChat.handleChatTurn.
   const recent = await listMessages(userId, 10);
+  const today = await userToday(userId);
   const history = recent.length
     ? `\n\nRecent conversation (oldest first):\n${recent
         .map((m) => `${m.direction === "inbound" ? "creator" : "coomander"}: ${m.text}`)
@@ -327,7 +328,7 @@ async function classifyMessage(userId: string, text: string, ctx: InboundContext
   const msg = await client.messages.create({
     model: MODEL,
     max_tokens: 300,
-    system: [{ type: "text", text: systemPrompt(ctx, personaMode, todayUTC()) + history, cache_control: { type: "ephemeral" } }],
+    system: [{ type: "text", text: systemPrompt(ctx, personaMode, today) + history, cache_control: { type: "ephemeral" } }],
     tool_choice: { type: "any" },
     tools: tools(),
     messages: [{ role: "user", content: text }],

--- a/node/lib/coomander/seed-defaults.ts
+++ b/node/lib/coomander/seed-defaults.ts
@@ -17,7 +17,7 @@ import crypto from "crypto";
 import { eq } from "drizzle-orm";
 import { getDb } from "@/lib/db";
 import { cadencePillars, cadenceBeats, coomanderSettings } from "@/lib/schema";
-import { todayUTC } from "./scheduling";
+import { userToday } from "./settings";
 
 const SOURCE = "v1_default";
 
@@ -121,7 +121,7 @@ export async function seedOpsDefaults(userId: string): Promise<SeedResult> {
   if (existing.length > 0) return { seeded: false, reason: "user already has pillars" };
 
   const now = Math.floor(Date.now() / 1000);
-  const today = todayUTC();
+  const today = await userToday(userId);
   let pillarCount = 0;
   let beatCount = 0;
 

--- a/node/lib/coomander/settings.ts
+++ b/node/lib/coomander/settings.ts
@@ -14,6 +14,7 @@
 import crypto from "crypto";
 import { and, eq, isNotNull } from "drizzle-orm";
 import { getDb } from "@/lib/db";
+import { DEFAULT_TIMEZONE, todayLocal } from "./consistency";
 import { user as userT, coomanderSettings as settingsT } from "@/lib/schema";
 
 export type NagFrequency = "tight" | "moderate" | "light";
@@ -29,6 +30,8 @@ export interface CoomanderSettingsResolved {
   userId: string;
   nagFrequency: NagFrequency;
   personaMode: PersonaMode;
+  /** IANA timezone for the creator's local day boundary (#183). */
+  timezone: string;
   pingTimesJson: string | null;
   companionConsentAt: number | null;
   opsSeededAt: number | null;
@@ -41,12 +44,18 @@ type SettingsRow =
   | {
       nag_frequency?: string | null;
       persona_mode?: string | null;
+      timezone?: string | null;
       ping_times_json?: string | null;
       companion_consent_at?: number | null;
       ops_seeded_at?: number | null;
       defaults_banner_dismissed_at?: number | null;
     }
   | undefined;
+
+export function pickTimezone(row: SettingsRow): string {
+  const v = (row?.timezone ?? "").trim();
+  return v.length > 0 ? v : DEFAULT_TIMEZONE;
+}
 
 export function pickNagFrequency(row: SettingsRow): NagFrequency {
   const v = (row?.nag_frequency ?? "").trim() as NagFrequency;
@@ -81,11 +90,22 @@ export async function getCoomanderSettings(userId: string): Promise<CoomanderSet
     userId,
     nagFrequency: pickNagFrequency(row),
     personaMode: pickPersonaMode(row),
+    timezone: pickTimezone(row),
     pingTimesJson: row?.ping_times_json ?? null,
     companionConsentAt: row?.companion_consent_at ?? null,
     opsSeededAt: row?.ops_seeded_at ?? null,
     defaultsBannerDismissedAt: row?.defaults_banner_dismissed_at ?? null,
   };
+}
+
+/** A user's resolved IANA timezone (falls back to DEFAULT_TIMEZONE). */
+export async function getTimezone(userId: string): Promise<string> {
+  return pickTimezone(await settingsRow(userId));
+}
+
+/** The creator's "today" (YYYY-MM-DD) in their local timezone (#183). */
+export async function userToday(userId: string): Promise<string> {
+  return todayLocal(await getTimezone(userId));
 }
 
 /** Each user the scheduled ping fans out to: opted-in AND with a Telegram chat. */
@@ -117,6 +137,7 @@ export async function resolveUserByChatId(chatId: string): Promise<string | null
 export interface SettingsPatch {
   nagFrequency?: NagFrequency;
   personaMode?: PersonaMode;
+  timezone?: string;
   pingTimesJson?: string | null;
   /** When true, stamp defaults_banner_dismissed_at = now. */
   dismissBanner?: boolean;
@@ -135,6 +156,7 @@ export async function updateCoomanderSettings(
     const set: Record<string, unknown> = { updated_at: now };
     if (patch.nagFrequency !== undefined) set.nag_frequency = patch.nagFrequency;
     if (patch.personaMode !== undefined) set.persona_mode = patch.personaMode;
+    if (patch.timezone !== undefined) set.timezone = patch.timezone;
     if (patch.pingTimesJson !== undefined) set.ping_times_json = patch.pingTimesJson;
     if (patch.dismissBanner) set.defaults_banner_dismissed_at = now;
     await db.update(settingsT).set(set).where(eq(settingsT.user_id, userId));
@@ -143,6 +165,7 @@ export async function updateCoomanderSettings(
       user_id: userId,
       nag_frequency: patch.nagFrequency ?? DEFAULT_NAG_FREQUENCY,
       persona_mode: patch.personaMode ?? DEFAULT_PERSONA_MODE,
+      timezone: patch.timezone ?? null,
       ping_times_json: patch.pingTimesJson ?? null,
       defaults_banner_dismissed_at: patch.dismissBanner ? now : null,
       created_at: now,

--- a/node/lib/coomander/todayModel.ts
+++ b/node/lib/coomander/todayModel.ts
@@ -12,8 +12,9 @@
  */
 
 import { computeBeatStatus, type BeatStatus } from "./beats";
-import { contentCushionDays, daysBetween, toDateUTC } from "./consistency";
-import { todayUTC } from "./scheduling";
+import { contentCushionDays, daysBetween, toDateLocal, todayLocal } from "./consistency";
+import { getDayState } from "./scheduling";
+import { getTimezone } from "./settings";
 import type {
   CadencePillar,
   CadenceBeat,
@@ -27,7 +28,6 @@ import { listBeats } from "./beats";
 import { listContent } from "./contentStates";
 import { listDrops } from "./drops";
 import { listProcurement } from "./procurement";
-import { getDayState } from "./scheduling";
 import { splitUrgent } from "./procurement";
 
 export interface TodayBeat {
@@ -70,8 +70,8 @@ function weekStart(date: string): string {
   return new Date(t).toISOString().slice(0, 10);
 }
 
-function dropDate(d: Drop): string {
-  return toDateUTC(d.dropped_at);
+function dropDate(d: Drop, tz: string): string {
+  return toDateLocal(d.dropped_at, tz);
 }
 
 /** Whether a drop counts toward a beat (matching id + platform constraint). */
@@ -85,6 +85,8 @@ function dropMatchesBeat(d: Drop, beat: CadenceBeat): boolean {
 
 export interface TodayInputs {
   date: string;
+  /** IANA timezone for bucketing drop timestamps to the creator's local day (#183). */
+  tz: string;
   pillars: CadencePillar[];
   beats: CadenceBeat[];
   drops: Drop[];
@@ -94,9 +96,10 @@ export interface TodayInputs {
 }
 
 export function buildTodayModel(inputs: TodayInputs): TodayModel {
-  const { date, pillars, beats, drops, content, procurement, dayQuality } = inputs;
+  const { date, tz, pillars, beats, drops, content, procurement, dayQuality } = inputs;
   const ws = weekStart(date);
   const dow = dayOfWeekMon(date);
+  const dropDay = (d: Drop): string => dropDate(d, tz);
 
   const beatsByPillar = new Map<string, CadenceBeat[]>();
   for (const b of beats) {
@@ -108,15 +111,15 @@ export function buildTodayModel(inputs: TodayInputs): TodayModel {
   const todayPillars: TodayPillar[] = pillars.map((pillar) => {
     const pBeats = (beatsByPillar.get(pillar.id) ?? []).map((beat): TodayBeat => {
       const beatDrops = drops.filter((d) => dropMatchesBeat(d, beat));
-      const actualToday = beatDrops.filter((d) => dropDate(d) === date).length;
+      const actualToday = beatDrops.filter((d) => dropDay(d) === date).length;
 
       if (beat.cadence_kind === "daily") {
         const res = computeBeatStatus({ cadenceKind: "daily", targetCount: beat.target_count, actualToday });
-        return { beat, expected_today: res.expected_today, actual_today: actualToday, status: res.status, streak_days: streakForBeat(beatDrops, date) };
+        return { beat, expected_today: res.expected_today, actual_today: actualToday, status: res.status, streak_days: streakForBeat(beatDrops, date, tz) };
       }
 
       if (beat.cadence_kind === "weekly") {
-        const actualWindow = beatDrops.filter((d) => { const dd = dropDate(d); return dd >= ws && dd <= date; }).length;
+        const actualWindow = beatDrops.filter((d) => { const dd = dropDay(d); return dd >= ws && dd <= date; }).length;
         const res = computeBeatStatus({ cadenceKind: "weekly", targetCount: beat.target_count, actualToday, actualWindow, dayOfWeek: dow });
         return { beat, expected_today: res.expected_today, actual_today: actualToday, status: res.status };
       }
@@ -124,7 +127,7 @@ export function buildTodayModel(inputs: TodayInputs): TodayModel {
       if (beat.cadence_kind === "window") {
         const start = beat.window_start ?? date;
         const end = beat.window_end ?? date;
-        const actualWindow = beatDrops.filter((d) => { const dd = dropDate(d); return dd >= start && dd <= end; }).length;
+        const actualWindow = beatDrops.filter((d) => { const dd = dropDay(d); return dd >= start && dd <= end; }).length;
         const totalDays = Math.max(1, daysBetween(start, end) + 1);
         const daysRemaining = Math.max(0, daysBetween(date, end));
         const res = computeBeatStatus({ cadenceKind: "window", targetCount: beat.target_count, actualToday, actualWindow, windowDaysRemaining: daysRemaining, windowTotalDays: totalDays });
@@ -145,14 +148,14 @@ export function buildTodayModel(inputs: TodayInputs): TodayModel {
   // Content pipeline counts.
   const pipeline = { drafted: 0, shot: 0, approved: 0, uploaded_to_edit: 0, edited: 0, scheduled: 0, shipped: 0 } as Record<ContentStateValue, number>;
   for (const c of content) pipeline[c.current_state]++;
-  const shippedToday = drops.filter((d) => d.kind === "shipped" && dropDate(d) === date).length;
+  const shippedToday = drops.filter((d) => d.kind === "shipped" && dropDay(d) === date).length;
 
   // Content cushion days.
   const readyCount = pipeline.approved + pipeline.scheduled;
   const dailyTarget = beats
     .filter((b) => b.cadence_kind === "daily" && (b.platform_specific !== "of"))
     .reduce((s, b) => s + b.target_count, 0);
-  const shippedDates = drops.filter((d) => d.kind === "shipped").map(dropDate).sort();
+  const shippedDates = drops.filter((d) => d.kind === "shipped").map(dropDay).sort();
   const lastShip = shippedDates.length ? shippedDates[shippedDates.length - 1] : null;
   const sinceLast = lastShip ? Math.max(0, daysBetween(lastShip, date)) : 0;
   const cushion = contentCushionDays({ readyCount, dailyTarget, daysSinceLastDrop: sinceLast });
@@ -181,8 +184,8 @@ export function buildTodayModel(inputs: TodayInputs): TodayModel {
 }
 
 /** Streak of consecutive days (ending today/yesterday) with a drop for this beat. */
-function streakForBeat(beatDrops: Drop[], today: string): number {
-  const days = new Set(beatDrops.map(dropDate));
+function streakForBeat(beatDrops: Drop[], today: string, tz: string): number {
+  const days = new Set(beatDrops.map((d) => dropDate(d, tz)));
   // inline of consistency.streakDays to avoid an extra import cycle for one call
   const shift = (d: string, n: number) => new Date(Date.parse(d + "T00:00:00Z") + n * 86400000).toISOString().slice(0, 10);
   let cursor: string;
@@ -197,7 +200,8 @@ function streakForBeat(beatDrops: Drop[], today: string): number {
 // ── async fetcher ─────────────────────────────────────────────────────────────
 
 export async function getTodayModel(userId: string, date?: string): Promise<TodayModel> {
-  const d = date ?? todayUTC();
+  const tz = await getTimezone(userId);
+  const d = date ?? todayLocal(tz);
   const [pillars, beats, content, drops, procurement, dayState] = await Promise.all([
     listPillars(userId),
     listBeats(userId),
@@ -208,6 +212,7 @@ export async function getTodayModel(userId: string, date?: string): Promise<Toda
   ]);
   return buildTodayModel({
     date: d,
+    tz,
     pillars,
     beats,
     content,

--- a/node/lib/schema.pg.ts
+++ b/node/lib/schema.pg.ts
@@ -438,6 +438,8 @@ export const coomanderSettings = pgTable("coomander_settings", {
   nag_frequency: text("nag_frequency").notNull().default("tight"),
   persona_mode: text("persona_mode").notNull().default("light_companion"),
   ping_times_json: text("ping_times_json"),
+  // IANA timezone for the creator's local day boundary (#183). NULL -> DEFAULT_TIMEZONE.
+  timezone: text("timezone"),
   companion_consent_at: integer("companion_consent_at"),
   ops_seeded_at: integer("ops_seeded_at"),
   defaults_banner_dismissed_at: integer("defaults_banner_dismissed_at"),

--- a/node/lib/schema.sqlite.ts
+++ b/node/lib/schema.sqlite.ts
@@ -465,6 +465,8 @@ export const coomanderSettings = sqliteTable("coomander_settings", {
   // light_companion (default) | full_companion | operational
   persona_mode: text("persona_mode").notNull().default("light_companion"),
   ping_times_json: text("ping_times_json"),
+  // IANA timezone for the creator's local day boundary (#183). NULL -> DEFAULT_TIMEZONE.
+  timezone: text("timezone"),
   companion_consent_at: integer("companion_consent_at"),
   ops_seeded_at: integer("ops_seeded_at"),
   defaults_banner_dismissed_at: integer("defaults_banner_dismissed_at"),

--- a/node/migrations/020_coomander_timezone.sql
+++ b/node/migrations/020_coomander_timezone.sql
@@ -1,0 +1,9 @@
+-- Per-creator timezone for the local day boundary (#183, Phase 1).
+--
+-- "today", drop bucketing, the Day 1-6 ramp, and the weekly window are computed
+-- in the creator's LOCAL calendar day instead of UTC, so a US creator's day no
+-- longer rolls over at ~6-7pm local (UTC midnight). NULL falls back to
+-- DEFAULT_TIMEZONE (env COOMANDER_TIMEZONE, default America/Chicago).
+-- Ported from geology's agents.timezone (migration 017 there).
+
+ALTER TABLE coomander_settings ADD COLUMN timezone TEXT;

--- a/node/tests/coomander-chat.test.ts
+++ b/node/tests/coomander-chat.test.ts
@@ -16,7 +16,8 @@ import { buildTodayModel } from "@/lib/coomander/todayModel";
 import { listBeats } from "@/lib/coomander/beats";
 import { listProcurement } from "@/lib/coomander/procurement";
 import { listDrops } from "@/lib/coomander/drops";
-import { getDayState, todayUTC } from "@/lib/coomander/scheduling";
+import { getDayState } from "@/lib/coomander/scheduling";
+import { userToday } from "@/lib/coomander/settings";
 import type {
   CadencePillar,
   CadenceBeat,
@@ -96,7 +97,7 @@ describe("handleChatTurn — tool-use turn writes domain rows", () => {
     expect(res.acted).toBe(true);
     expect(res.reply.length).toBeGreaterThan(0);
 
-    const day = await getDayState(userId, todayUTC());
+    const day = await getDayState(userId, await userToday(userId));
     expect(day?.day_quality).toBe("bad");
   });
 

--- a/node/tests/coomander-timezone.test.ts
+++ b/node/tests/coomander-timezone.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_TIMEZONE,
+  todayLocal,
+  toDateLocal,
+  toDateUTC,
+} from "@/lib/coomander/consistency";
+import { pickTimezone, getTimezone, userToday } from "@/lib/coomander/settings";
+import { buildTodayModel } from "@/lib/coomander/todayModel";
+import type { CadencePillar, CadenceBeat } from "@/lib/schema";
+import { getRawDb } from "@/lib/db";
+// Importing the db helper bootstraps the Better Auth `user` table schema.
+import "./helpers/db";
+
+const unix = (iso: string) => Math.floor(Date.parse(iso) / 1000);
+
+// ── 1. toDateLocal / todayLocal day-boundary semantics ───────────────────────
+describe("toDateLocal / todayLocal — local day boundary (#183)", () => {
+  // 2026-06-17T02:00:00Z == 2026-06-16 21:00 CDT (UTC-5). The evening-CDT
+  // timestamp is the PREVIOUS calendar day locally but the NEXT day in UTC.
+  const eveningCdt = unix("2026-06-17T02:00:00Z");
+
+  it("buckets an evening-CDT timestamp to the LOCAL date, not the UTC date", () => {
+    expect(toDateLocal(eveningCdt, "America/Chicago")).toBe("2026-06-16");
+    expect(toDateUTC(eveningCdt)).toBe("2026-06-17");
+  });
+
+  it("local and UTC agree for an afternoon timestamp (no boundary crossing)", () => {
+    // 2026-06-16T18:00:00Z == 2026-06-16 13:00 CDT — same calendar day both ways.
+    const afternoon = unix("2026-06-16T18:00:00Z");
+    expect(toDateLocal(afternoon, "America/Chicago")).toBe("2026-06-16");
+    expect(toDateUTC(afternoon)).toBe("2026-06-16");
+  });
+
+  it("UTC tz makes toDateLocal agree with toDateUTC", () => {
+    expect(toDateLocal(eveningCdt, "UTC")).toBe(toDateUTC(eveningCdt));
+    expect(toDateLocal(eveningCdt, "UTC")).toBe("2026-06-17");
+  });
+
+  it("todayLocal renders YYYY-MM-DD for a fixed `now` in the given tz", () => {
+    const now = new Date("2026-06-17T02:00:00Z");
+    expect(todayLocal("America/Chicago", now)).toBe("2026-06-16");
+    expect(todayLocal("UTC", now)).toBe("2026-06-17");
+  });
+});
+
+// ── 2. pickTimezone (pure) ───────────────────────────────────────────────────
+describe("pickTimezone — default fallback + trimming", () => {
+  it("undefined row → DEFAULT_TIMEZONE", () => {
+    expect(pickTimezone(undefined)).toBe(DEFAULT_TIMEZONE);
+  });
+
+  it("missing/empty/whitespace timezone → DEFAULT_TIMEZONE", () => {
+    expect(pickTimezone({})).toBe(DEFAULT_TIMEZONE);
+    expect(pickTimezone({ timezone: null })).toBe(DEFAULT_TIMEZONE);
+    expect(pickTimezone({ timezone: "" })).toBe(DEFAULT_TIMEZONE);
+    expect(pickTimezone({ timezone: "   " })).toBe(DEFAULT_TIMEZONE);
+  });
+
+  it("returns the trimmed value when set", () => {
+    expect(pickTimezone({ timezone: "America/New_York" })).toBe(
+      "America/New_York",
+    );
+    expect(pickTimezone({ timezone: "  Europe/London  " })).toBe(
+      "Europe/London",
+    );
+  });
+
+  it("DEFAULT_TIMEZONE is America/Chicago unless overridden by env", () => {
+    expect(DEFAULT_TIMEZONE).toBe(
+      process.env.COOMANDER_TIMEZONE || "America/Chicago",
+    );
+  });
+});
+
+// ── 3. buildTodayModel local bucketing (the core fix) ────────────────────────
+type Drop = {
+  id: string;
+  user_id: string;
+  beat_id: string | null;
+  kind: string;
+  source: string;
+  platform: string | null;
+  external_ref: string | null;
+  content_state_id: string | null;
+  payload_json: string;
+  dropped_at: number;
+  created_at: number;
+};
+
+function pillar(over: Partial<CadencePillar> = {}): CadencePillar {
+  return {
+    id: "p1",
+    user_id: "u1",
+    name: "Content",
+    kind: "content",
+    display_order: 0,
+    archived_at: null,
+    created_at: 0,
+    updated_at: 0,
+    ...over,
+  } as unknown as CadencePillar;
+}
+
+function beat(over: Partial<CadenceBeat> = {}): CadenceBeat {
+  return {
+    id: "b1",
+    user_id: "u1",
+    pillar_id: "p1",
+    name: "Reels",
+    cadence_kind: "daily",
+    target_count: 3,
+    buffer_goal_days: null,
+    window_start: null,
+    window_end: null,
+    priority: "med",
+    platform_specific: null,
+    subtype: null,
+    active: 1,
+    archived_at: null,
+    notes: null,
+    created_at: 0,
+    updated_at: 0,
+    ...over,
+  } as unknown as CadenceBeat;
+}
+
+function drop(over: Partial<Drop> = {}): Drop {
+  return {
+    id: "d1",
+    user_id: "u1",
+    beat_id: "b1",
+    kind: "shipped",
+    source: "manual",
+    platform: null,
+    external_ref: null,
+    content_state_id: null,
+    payload_json: "{}",
+    dropped_at: 0,
+    created_at: 0,
+    ...over,
+  };
+}
+
+function buildModel(
+  tz: string,
+  over: Partial<Parameters<typeof buildTodayModel>[0]> = {},
+): ReturnType<typeof buildTodayModel> {
+  return buildTodayModel({
+    date: "2026-06-16",
+    tz,
+    pillars: [pillar()],
+    beats: [beat()],
+    drops: [],
+    content: [],
+    procurement: [],
+    dayQuality: null,
+    ...over,
+  } as unknown as Parameters<typeof buildTodayModel>[0]);
+}
+
+function findBeat(model: ReturnType<typeof buildTodayModel>, beatId: string) {
+  for (const p of model.pillars) {
+    for (const b of p.beats) {
+      if (b.beat.id === beatId) return b;
+    }
+  }
+  return undefined;
+}
+
+describe("buildTodayModel — tz drives day bucketing (#183 core fix)", () => {
+  // Evening-CDT shipped drop: 2026-06-17T02:00:00Z == 2026-06-16 21:00 CDT.
+  // It belongs to the local "today" (2026-06-16) but to tomorrow in UTC.
+  const eveningCdtDrop = drop({
+    beat_id: "b1",
+    kind: "shipped",
+    dropped_at: unix("2026-06-17T02:00:00Z"),
+  });
+
+  it("America/Chicago: an evening-CDT drop counts toward the local today", () => {
+    const m = buildModel("America/Chicago", {
+      drops: [eveningCdtDrop] as unknown as never,
+    });
+    const b = findBeat(m, "b1")!;
+    expect(b.actual_today).toBe(1);
+    expect(m.content_pipeline.shipped_today).toBe(1);
+  });
+
+  it("UTC: the same drop does NOT count toward 2026-06-16 (proves tz drives bucketing)", () => {
+    const m = buildModel("UTC", {
+      drops: [eveningCdtDrop] as unknown as never,
+    });
+    const b = findBeat(m, "b1")!;
+    expect(b.actual_today).toBe(0);
+    expect(m.content_pipeline.shipped_today).toBe(0);
+  });
+});
+
+// ── 4. getTimezone / userToday DB fallback ───────────────────────────────────
+let userIdCounter = 0;
+function seedUser(): string {
+  const id = `coomander-tz-user-${Date.now()}-${userIdCounter++}`;
+  const email = `${id}@test.com`;
+  const now = Math.floor(Date.now() / 1000);
+  getRawDb()
+    .prepare(
+      "INSERT INTO user (id, email, emailVerified, createdAt, updatedAt, isAdmin, disabled, coomanderEnabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .run(id, email, 1, now, now, 0, 0, 1);
+  return id;
+}
+
+describe("getTimezone / userToday — DB fallback with no settings row", () => {
+  it("getTimezone falls back to DEFAULT_TIMEZONE when no coomander_settings row exists", async () => {
+    const userId = seedUser();
+    expect(await getTimezone(userId)).toBe(DEFAULT_TIMEZONE);
+  });
+
+  it("userToday equals todayLocal(DEFAULT_TIMEZONE) for an unconfigured user", async () => {
+    const userId = seedUser();
+    expect(await userToday(userId)).toBe(todayLocal(DEFAULT_TIMEZONE));
+  });
+});


### PR DESCRIPTION
Phase 1 of #183. Ports geology's local-day pattern: "today", drop bucketing, the ramp, and all daily entry points use the creator's LOCAL day instead of UTC — fixes the "nothing shipped today" bug a US creator hit at 8 PM. Per-user `coomander_settings.timezone` (migration 020; NULL → `America/Chicago`). Weekly-review internal bucketing deferred (noted in #183). Typecheck + 472 tests pass (new tz boundary + local-bucketing tests).

QA: N/A — verified by owner manual re-test over Telegram (a drop logged in the evening counts toward the local day), per #183 Phase 1 acceptance criteria.