### PR TITLE
Release sync: enable agents worker in prod (route + flag)

### DIFF
--- a/apps/agents/wrangler.toml
+++ b/apps/agents/wrangler.toml
@@ -51,9 +51,9 @@ name = "coomander-agents"
 # worker's custom-domain route on the same host, so Cloudflare routes
 # `/agents/*` here and everything else to the app worker (`coomander`).
 # Uncomment to go live:
-# routes = [
-#   { pattern = "coomander.com/agents/*", zone_name = "coomander.com" },
-# ]
+routes = [
+  { pattern = "coomander.com/agents/*", zone_name = "coomander.com" },
+]
 
 [env.production.vars]
 # In prod the agent reaches the app worker over the WEB service binding below

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -53,6 +53,8 @@ APP_URL = "https://coomander.com"
 # Cloudflare Email Service sender (migrated off Resend). Must be an address on a
 # domain onboarded at Cloudflare → Email → Email Sending.
 EMAIL_FROM = "Coomander <noreply@coomander.com>"
+# Agents worker chat enabled in prod (#192) — WS streaming + schedule(); JSON chat is the fallback.
+FLAG_COOMANDER_AGENTS_CHAT = "true"
 
 # ── Cloudflare Email Service (send_email binding) ──────────────────────────
 # Tier-1 transport for lib/email.ts on Workers (zero-config; the binding


### PR DESCRIPTION
Syncs main to the deployed prod state (agents route + FLAG_COOMANDER_AGENTS_CHAT). Part of epic #189.