### PR TITLE
Mobile: stream chat over the agents-worker WebSocket, with POST fallback (#199)

### DIFF
--- a/apps/mobile/src/app/(app)/index.tsx
+++ b/apps/mobile/src/app/(app)/index.tsx
@@ -20,6 +20,20 @@ import { getThread, streamMessage, type CoomanderMessage } from "@/lib/api";
 import { useTheme } from "@/lib/theme";
 import { Screen } from "@/components/screen";
 import { ApiError } from "@coomander/core";
+import {
+  useAgentSocket,
+  fetchAgentChatFlag,
+  type SocketStatus,
+} from "@/lib/use-agent-socket";
+import {
+  reduce,
+  resetTurn,
+  shouldUseSocket,
+  initialStreamState,
+  COOMANDER_CONVERSATION_ID,
+  type ServerFrame,
+  type StreamState,
+} from "@/lib/agent-socket-protocol";
 
 // ---------------------------------------------------------------------------
 // Tag stripping (matches the web's stripTags)
@@ -167,21 +181,35 @@ export default function CoomanderChatScreen() {
   const [enabled, setEnabled] = useState(true);
   const [speakingId, setSpeakingId] = useState<string | null>(null);
 
+  // ── Agents-worker WebSocket transport, flag-gated (#199) ──────────────
+  // wsEnabled mirrors the `coomander-agents-chat` flag; the socket only opens
+  // while flag-on + ops enabled. `stream` is the live WebSocket turn state
+  // (folded from server frames via the pure `reduce`); wsTurnRef marks a turn
+  // sent over the socket so a mid-turn drop cleans up without touching the
+  // SSE-path turns. The POST/SSE path stays the universal fallback.
+  const [wsEnabled, setWsEnabled] = useState(false);
+  const [stream, setStream] = useState<StreamState>(initialStreamState);
+  const wsTurnRef = useRef<{ userMsgId: string } | null>(null);
+  const proactiveProcessedRef = useRef(0);
+
+  // Reload the canonical unified thread (real ids, ordering, tool side effects).
+  // Used on mount and after a WS turn finishes / a persisted proactive arrives.
+  const loadThread = useCallback(async () => {
+    const thread = await getThread();
+    setEnabled(thread.enabled);
+    setMessages(
+      thread.messages.map((m: CoomanderMessage) => ({
+        id: m.id,
+        role: m.role,
+        content: m.content,
+      })),
+    );
+  }, []);
+
   // ── Load the unified thread on mount ──────────────────────────────────
   useEffect(() => {
     let active = true;
-    getThread()
-      .then((thread) => {
-        if (!active) return;
-        setEnabled(thread.enabled);
-        setMessages(
-          thread.messages.map((m: CoomanderMessage) => ({
-            id: m.id,
-            role: m.role,
-            content: m.content,
-          })),
-        );
-      })
+    loadThread()
       .catch((e) => {
         if (!active) return;
         setError(
@@ -194,7 +222,102 @@ export default function CoomanderChatScreen() {
     return () => {
       active = false;
     };
+  }, [loadThread]);
+
+  // Resolve the coomander-agents-chat flag once on mount. The socket only
+  // connects after this is true AND ops is enabled; flag-off (the default) keeps
+  // the POST/SSE path.
+  useEffect(() => {
+    let active = true;
+    fetchAgentChatFlag()
+      .then((on) => {
+        if (active) setWsEnabled(on);
+      })
+      .catch(() => {
+        // Flag endpoint unavailable — stay on the POST/SSE path.
+      });
+    return () => {
+      active = false;
+    };
   }, []);
+
+  // Fold every server frame into the pure stream state. The effects below react
+  // to the resulting `done` / `error` / `proactive` transitions.
+  const onFrame = useCallback((frame: ServerFrame) => {
+    setStream((s) => reduce(s, frame));
+  }, []);
+
+  const onStatusChange = useCallback((status: SocketStatus) => {
+    // A mid-turn disconnect would otherwise leave the spinner forever. Keep the
+    // optimistic user bubble (AC), surface a soft error, and reset the stream.
+    if (status === "closed" && wsTurnRef.current) {
+      wsTurnRef.current = null;
+      setThinking(false);
+      setStream(resetTurn);
+      setError("Connection lost. Tap send to try again.");
+    }
+  }, []);
+
+  const { ready, send } = useAgentSocket({
+    enabled: wsEnabled && enabled,
+    onFrame,
+    onStatusChange,
+  });
+
+  // First streamed token means the model is producing — drop the "Thinking…" bar.
+  useEffect(() => {
+    if (stream.streamingText) setThinking(false);
+  }, [stream.streamingText]);
+
+  // Turn finished: reload the canonical thread, then drop the live bubble. The
+  // bubble shows finalText until the reload replaces it → no flicker. wsTurnRef
+  // is cleared synchronously so a post-done close isn't mistaken for a drop.
+  useEffect(() => {
+    if (!stream.done) return;
+    wsTurnRef.current = null;
+    setThinking(false);
+    let active = true;
+    (async () => {
+      await loadThread().catch(() => {});
+      if (active) setStream(resetTurn);
+    })();
+    return () => {
+      active = false;
+    };
+  }, [stream.done, loadThread]);
+
+  // Error frame: surface it, keep the optimistic user bubble, clear the stream.
+  useEffect(() => {
+    if (!stream.error) return;
+    setError(stream.error);
+    setThinking(false);
+    wsTurnRef.current = null;
+    setStream(resetTurn);
+  }, [stream.error]);
+
+  // Proactive (agent-initiated) messages. Persisted ones (carry a
+  // conversationId) are already in the thread server-side → reload to render in
+  // place; standalone ones are appended directly. A processed-index ref drains
+  // the append-only queue exactly once.
+  useEffect(() => {
+    if (stream.proactive.length <= proactiveProcessedRef.current) return;
+    const fresh = stream.proactive.slice(proactiveProcessedRef.current);
+    proactiveProcessedRef.current = stream.proactive.length;
+    if (fresh.some((p) => p.conversationId)) {
+      loadThread().catch(() => {});
+    }
+    const standalone = fresh.filter((p) => !p.conversationId);
+    if (standalone.length > 0) {
+      setMessages((prev) => [
+        ...prev,
+        ...standalone.map((p) => ({
+          id: tmpId("proactive"),
+          role: "assistant" as const,
+          content: p.message,
+        })),
+      ]);
+    }
+  }, [stream.proactive, loadThread]);
 
   // ── Auto-scroll to the bottom on new content ──────────────────────────
   useEffect(() => {
@@ -211,6 +334,26 @@ export default function CoomanderChatScreen() {
     Keyboard.dismiss();
     setInput("");
     setError(null);
+
+    // ── WebSocket path (#199) — flag on, ops enabled, socket open. ──────────
+    // Streams the turn token-by-token over the agents Worker. onFrame folds the
+    // frames into `stream`; the effects above reload the thread on done / surface
+    // errors. Falls through to the SSE path whenever the socket isn't open.
+    if (shouldUseSocket({ flagEnabled: wsEnabled, entitled: enabled, socketReady: ready() })) {
+      const wsUserMsg: UIMessage = { id: tmpId("u"), role: "user", content: text };
+      setMessages((prev) => [...prev, wsUserMsg]);
+      setStream(resetTurn);
+      setThinking(true);
+      const ok = send({ conversationId: COOMANDER_CONVERSATION_ID, message: text });
+      if (ok) {
+        wsTurnRef.current = { userMsgId: wsUserMsg.id };
+        return;
+      }
+      // send() lost the race (socket dropped between ready() and send): roll back
+      // the optimistic bubble and fall through to the SSE path below.
+      setMessages((prev) => prev.filter((m) => m.id !== wsUserMsg.id));
+      setThinking(false);
+    }
 
     // Optimistic user bubble + an empty assistant bubble we stream tokens into.
     const userMsg: UIMessage = { id: tmpId("u"), role: "user", content: text };
@@ -327,6 +470,11 @@ export default function CoomanderChatScreen() {
     [colors, speakingId],
   );
 
+  // The in-progress WebSocket assistant bubble: streamingText while tokens
+  // arrive, then finalText for the brief window before the canonical reload
+  // replaces it (no flicker). Null when no WS turn is streaming.
+  const wsLiveText = stream.streamingText ?? stream.finalText;
+
   return (
     <Screen>
       {/* Header — brand + sign out */}
@@ -383,11 +531,26 @@ export default function CoomanderChatScreen() {
             onContentSizeChange={() =>
               flatListRef.current?.scrollToEnd({ animated: true })
             }
+            ListFooterComponent={
+              wsLiveText && wsLiveText.length > 0 ? (
+                <View style={[styles.msgRow, styles.msgRowAssistant]}>
+                  <View
+                    style={[
+                      styles.msgBubble,
+                      styles.msgBubbleAssistant,
+                      { backgroundColor: colors.card, borderColor: colors.border },
+                    ]}
+                  >
+                    <MessageText content={wsLiveText} colors={colors} isUser={false} />
+                  </View>
+                </View>
+              ) : null
+            }
           />
         )}
 
-        {/* Thinking indicator (no streaming — POST is in flight) */}
-        {thinking ? (
+        {/* Thinking indicator — POST in flight, or WS turn before its first token. */}
+        {thinking && !wsLiveText ? (
           <View style={[styles.typingBar, { borderTopColor: colors.border }]}>
             <ActivityIndicator size="small" color={colors.primary} />
             <Text style={[styles.typingText, { color: colors.mutedForeground }]}>

--- a/apps/mobile/src/lib/__tests__/agent-socket-protocol.test.ts
+++ b/apps/mobile/src/lib/__tests__/agent-socket-protocol.test.ts
@@ -1,0 +1,645 @@
+import {
+  COOMANDER_CONVERSATION_ID,
+  AGENTS_CHAT_FLAG,
+  AGENT_PATH_PREFIX,
+  parseServerFrame,
+  encodeChatFrame,
+  buildWsUrl,
+  shouldUseSocket,
+  initialStreamState,
+  reduce,
+  resetTurn,
+} from "@/lib/agent-socket-protocol";
+
+describe("exported constants", () => {
+  it("COOMANDER_CONVERSATION_ID is 'coomander'", () => {
+    expect(COOMANDER_CONVERSATION_ID).toBe("coomander");
+  });
+
+  it("AGENTS_CHAT_FLAG is 'coomander-agents-chat'", () => {
+    expect(AGENTS_CHAT_FLAG).toBe("coomander-agents-chat");
+  });
+
+  it("AGENT_PATH_PREFIX is '/agents/app-agent'", () => {
+    expect(AGENT_PATH_PREFIX).toBe("/agents/app-agent");
+  });
+});
+
+describe("parseServerFrame", () => {
+  describe("non-string / unparseable input → null", () => {
+    it("returns null for a number", () => {
+      expect(parseServerFrame(5)).toBeNull();
+    });
+
+    it("returns null for an object", () => {
+      expect(parseServerFrame({ type: "token", text: "hi" })).toBeNull();
+    });
+
+    it("returns null for null", () => {
+      expect(parseServerFrame(null)).toBeNull();
+    });
+
+    it("returns null for undefined", () => {
+      expect(parseServerFrame(undefined)).toBeNull();
+    });
+
+    it("returns null for an array", () => {
+      expect(parseServerFrame([1, 2, 3])).toBeNull();
+    });
+
+    it("returns null for a boolean", () => {
+      expect(parseServerFrame(true)).toBeNull();
+    });
+
+    it("returns null for an ArrayBuffer-like value", () => {
+      expect(parseServerFrame(new ArrayBuffer(8))).toBeNull();
+    });
+
+    it("returns null for malformed JSON string", () => {
+      expect(parseServerFrame("{not json")).toBeNull();
+      expect(parseServerFrame("{")).toBeNull();
+      expect(parseServerFrame("")).toBeNull();
+    });
+  });
+
+  describe("valid JSON that is not an object → null", () => {
+    it("returns null for a JSON number", () => {
+      expect(parseServerFrame("5")).toBeNull();
+    });
+
+    it("returns null for a JSON boolean", () => {
+      expect(parseServerFrame("true")).toBeNull();
+    });
+
+    it("returns null for JSON null", () => {
+      expect(parseServerFrame("null")).toBeNull();
+    });
+
+    it("returns null for a JSON string literal", () => {
+      expect(parseServerFrame('"hi"')).toBeNull();
+    });
+
+    it("returns null for a JSON array", () => {
+      expect(parseServerFrame("[1,2,3]")).toBeNull();
+    });
+  });
+
+  describe("missing / unknown type → null", () => {
+    it("returns null when type is missing", () => {
+      expect(parseServerFrame(JSON.stringify({ text: "hi" }))).toBeNull();
+    });
+
+    it("returns null for an unknown type", () => {
+      expect(
+        parseServerFrame(JSON.stringify({ type: "bananas", text: "hi" }))
+      ).toBeNull();
+    });
+
+    it("returns null for an empty object", () => {
+      expect(parseServerFrame("{}")).toBeNull();
+    });
+  });
+
+  describe("conversation frame", () => {
+    it("parses a valid conversation frame and returns only the two keys", () => {
+      const result = parseServerFrame(
+        JSON.stringify({ type: "conversation", conversationId: "abc", extra: 1 })
+      );
+      expect(result).toEqual({ type: "conversation", conversationId: "abc" });
+    });
+
+    it("returns null when conversationId is missing", () => {
+      expect(
+        parseServerFrame(JSON.stringify({ type: "conversation" }))
+      ).toBeNull();
+    });
+
+    it("returns null when conversationId is not a string", () => {
+      expect(
+        parseServerFrame(
+          JSON.stringify({ type: "conversation", conversationId: 5 })
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe("token frame", () => {
+    it("parses a valid token frame", () => {
+      const result = parseServerFrame(
+        JSON.stringify({ type: "token", text: "hello" })
+      );
+      expect(result).toEqual({ type: "token", text: "hello" });
+    });
+
+    it("treats an empty string text as valid", () => {
+      const result = parseServerFrame(
+        JSON.stringify({ type: "token", text: "" })
+      );
+      expect(result).toEqual({ type: "token", text: "" });
+    });
+
+    it("returns null when text is missing", () => {
+      expect(parseServerFrame(JSON.stringify({ type: "token" }))).toBeNull();
+    });
+
+    it("returns null when text is the wrong type (number)", () => {
+      expect(
+        parseServerFrame(JSON.stringify({ type: "token", text: 5 }))
+      ).toBeNull();
+    });
+  });
+
+  describe("done frame", () => {
+    it("parses a valid done frame", () => {
+      const result = parseServerFrame(
+        JSON.stringify({
+          type: "done",
+          conversationId: "c1",
+          fullText: "final",
+        })
+      );
+      expect(result).toEqual({
+        type: "done",
+        conversationId: "c1",
+        fullText: "final",
+      });
+    });
+
+    it("returns null when fullText is missing", () => {
+      expect(
+        parseServerFrame(JSON.stringify({ type: "done", conversationId: "c" }))
+      ).toBeNull();
+    });
+
+    it("returns null when conversationId is missing", () => {
+      expect(
+        parseServerFrame(JSON.stringify({ type: "done", fullText: "final" }))
+      ).toBeNull();
+    });
+
+    it("returns null when conversationId is non-string", () => {
+      expect(
+        parseServerFrame(
+          JSON.stringify({ type: "done", conversationId: 1, fullText: "final" })
+        )
+      ).toBeNull();
+    });
+
+    it("returns null when fullText is non-string", () => {
+      expect(
+        parseServerFrame(
+          JSON.stringify({ type: "done", conversationId: "c", fullText: 1 })
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe("error frame", () => {
+    it("parses a valid error frame", () => {
+      const result = parseServerFrame(
+        JSON.stringify({ type: "error", message: "boom" })
+      );
+      expect(result).toEqual({ type: "error", message: "boom" });
+    });
+
+    it("returns null when message is missing", () => {
+      expect(parseServerFrame(JSON.stringify({ type: "error" }))).toBeNull();
+    });
+
+    it("returns null when message is non-string", () => {
+      expect(
+        parseServerFrame(JSON.stringify({ type: "error", message: 5 }))
+      ).toBeNull();
+    });
+  });
+
+  describe("proactive frame", () => {
+    it("parses a proactive frame with message only and omits conversationId key", () => {
+      const result = parseServerFrame(
+        JSON.stringify({ type: "proactive", message: "ping" })
+      );
+      expect(result).toEqual({ type: "proactive", message: "ping" });
+      expect(result).not.toHaveProperty("conversationId");
+    });
+
+    it("includes conversationId when it is a string", () => {
+      const result = parseServerFrame(
+        JSON.stringify({
+          type: "proactive",
+          message: "ping",
+          conversationId: "c9",
+        })
+      );
+      expect(result).toEqual({
+        type: "proactive",
+        message: "ping",
+        conversationId: "c9",
+      });
+    });
+
+    it("omits conversationId key when it is non-string", () => {
+      const result = parseServerFrame(
+        JSON.stringify({
+          type: "proactive",
+          message: "ping",
+          conversationId: 5,
+        })
+      );
+      expect(result).toEqual({ type: "proactive", message: "ping" });
+      expect(result).not.toHaveProperty("conversationId");
+    });
+
+    it("returns null when message is missing", () => {
+      expect(parseServerFrame(JSON.stringify({ type: "proactive" }))).toBeNull();
+    });
+
+    it("returns null when message is non-string", () => {
+      expect(
+        parseServerFrame(JSON.stringify({ type: "proactive", message: 5 }))
+      ).toBeNull();
+    });
+  });
+});
+
+describe("encodeChatFrame", () => {
+  it("encodes without userContext (no userContext key)", () => {
+    const json = encodeChatFrame({ conversationId: "c1", message: "hi" });
+    expect(JSON.parse(json)).toEqual({
+      type: "chat",
+      conversationId: "c1",
+      message: "hi",
+    });
+    expect(JSON.parse(json)).not.toHaveProperty("userContext");
+  });
+
+  it("encodes with userContext when provided", () => {
+    const json = encodeChatFrame({
+      conversationId: "c1",
+      message: "hi",
+      userContext: "ctx",
+    });
+    expect(JSON.parse(json)).toEqual({
+      type: "chat",
+      conversationId: "c1",
+      message: "hi",
+      userContext: "ctx",
+    });
+  });
+
+  it("preserves a null conversationId in the JSON", () => {
+    const json = encodeChatFrame({ conversationId: null, message: "hi" });
+    expect(json).toContain('"conversationId":null');
+    expect(JSON.parse(json)).toEqual({
+      type: "chat",
+      conversationId: null,
+      message: "hi",
+    });
+  });
+
+  it("round-trips to a deep-equal object", () => {
+    const input = {
+      conversationId: "abc",
+      message: "round trip",
+      userContext: "extra",
+    };
+    expect(JSON.parse(encodeChatFrame(input))).toEqual({
+      type: "chat",
+      ...input,
+    });
+  });
+});
+
+describe("buildWsUrl", () => {
+  it("swaps https → wss and appends default name 'me'", () => {
+    expect(buildWsUrl("https://coomander.com")).toBe(
+      "wss://coomander.com/agents/app-agent/me"
+    );
+  });
+
+  it("swaps http → ws and appends default name 'me'", () => {
+    expect(buildWsUrl("http://localhost:3005")).toBe(
+      "ws://localhost:3005/agents/app-agent/me"
+    );
+  });
+
+  it("strips a trailing slash before appending", () => {
+    expect(buildWsUrl("https://x.ts.net/")).toBe(
+      "wss://x.ts.net/agents/app-agent/me"
+    );
+  });
+
+  it("produces the same result with or without a trailing slash", () => {
+    expect(buildWsUrl("https://x.com/")).toBe(buildWsUrl("https://x.com"));
+  });
+
+  it("strips multiple trailing slashes", () => {
+    expect(buildWsUrl("https://x.com///")).toBe(
+      "wss://x.com/agents/app-agent/me"
+    );
+  });
+
+  it("uses the provided name", () => {
+    expect(buildWsUrl("https://coomander.com", "abc")).toBe(
+      "wss://coomander.com/agents/app-agent/abc"
+    );
+  });
+
+  it("encodeURIComponent-s a name with a space", () => {
+    expect(buildWsUrl("https://coomander.com", "a b")).toBe(
+      "wss://coomander.com/agents/app-agent/a%20b"
+    );
+  });
+
+  it("encodeURIComponent-s a name with reserved characters", () => {
+    expect(buildWsUrl("https://coomander.com", "a/b?c")).toBe(
+      "wss://coomander.com/agents/app-agent/a%2Fb%3Fc"
+    );
+  });
+
+  it("treats the scheme case-insensitively (HTTPS)", () => {
+    expect(buildWsUrl("HTTPS://coomander.com")).toBe(
+      "wss://coomander.com/agents/app-agent/me"
+    );
+  });
+
+  it("treats the scheme case-insensitively (HTTP)", () => {
+    expect(buildWsUrl("HTTP://localhost:3005")).toBe(
+      "ws://localhost:3005/agents/app-agent/me"
+    );
+  });
+});
+
+describe("shouldUseSocket", () => {
+  it("returns true when flag on, entitled true, ready true", () => {
+    expect(
+      shouldUseSocket({ flagEnabled: true, entitled: true, socketReady: true })
+    ).toBe(true);
+  });
+
+  it("returns true when entitled is undefined (flag on, ready true)", () => {
+    expect(shouldUseSocket({ flagEnabled: true, socketReady: true })).toBe(true);
+  });
+
+  it("returns false when entitled is explicitly false", () => {
+    expect(
+      shouldUseSocket({ flagEnabled: true, entitled: false, socketReady: true })
+    ).toBe(false);
+  });
+
+  it("returns false when the flag is off (even if everything else passes)", () => {
+    expect(
+      shouldUseSocket({ flagEnabled: false, entitled: true, socketReady: true })
+    ).toBe(false);
+  });
+
+  it("returns false when the flag is off and entitled is undefined", () => {
+    expect(shouldUseSocket({ flagEnabled: false, socketReady: true })).toBe(
+      false
+    );
+  });
+
+  it("returns false when socketReady is false", () => {
+    expect(
+      shouldUseSocket({ flagEnabled: true, entitled: true, socketReady: false })
+    ).toBe(false);
+  });
+
+  it("returns false when socketReady is false and entitled undefined", () => {
+    expect(shouldUseSocket({ flagEnabled: true, socketReady: false })).toBe(
+      false
+    );
+  });
+});
+
+describe("stream reducer", () => {
+  describe("initialStreamState", () => {
+    it("matches the documented initial state", () => {
+      expect(initialStreamState).toEqual({
+        streamingText: null,
+        finalText: null,
+        conversationId: null,
+        done: false,
+        error: null,
+        proactive: [],
+      });
+    });
+  });
+
+  describe("reduce — conversation", () => {
+    it("sets conversationId without touching text fields", () => {
+      const next = reduce(initialStreamState, {
+        type: "conversation",
+        conversationId: "c1",
+      });
+      expect(next).toEqual({
+        streamingText: null,
+        finalText: null,
+        conversationId: "c1",
+        done: false,
+        error: null,
+        proactive: [],
+      });
+    });
+
+    it("returns a new object reference and does not mutate input", () => {
+      const before = { ...initialStreamState };
+      const next = reduce(initialStreamState, {
+        type: "conversation",
+        conversationId: "c1",
+      });
+      expect(next).not.toBe(initialStreamState);
+      expect(initialStreamState).toEqual(before);
+    });
+  });
+
+  describe("reduce — token", () => {
+    it("becomes the token text from a null streamingText", () => {
+      const next = reduce(initialStreamState, { type: "token", text: "ab" });
+      expect(next.streamingText).toBe("ab");
+    });
+
+    it("concatenates onto existing streamingText", () => {
+      const state = { ...initialStreamState, streamingText: "ab" };
+      const next = reduce(state, { type: "token", text: "cd" });
+      expect(next.streamingText).toBe("abcd");
+    });
+
+    it("returns a new object reference and does not mutate input", () => {
+      const state = { ...initialStreamState, streamingText: "ab" };
+      const before = { ...state };
+      const next = reduce(state, { type: "token", text: "cd" });
+      expect(next).not.toBe(state);
+      expect(state).toEqual(before);
+    });
+  });
+
+  describe("reduce — done", () => {
+    it("clears streamingText, sets finalText, conversationId, and done", () => {
+      const state = { ...initialStreamState, streamingText: "partial" };
+      const next = reduce(state, {
+        type: "done",
+        conversationId: "c2",
+        fullText: "the full text",
+      });
+      expect(next).toEqual({
+        streamingText: null,
+        finalText: "the full text",
+        conversationId: "c2",
+        done: true,
+        error: null,
+        proactive: [],
+      });
+    });
+
+    it("returns a new object reference and does not mutate input", () => {
+      const state = { ...initialStreamState, streamingText: "partial" };
+      const before = { ...state };
+      const next = reduce(state, {
+        type: "done",
+        conversationId: "c2",
+        fullText: "x",
+      });
+      expect(next).not.toBe(state);
+      expect(state).toEqual(before);
+    });
+  });
+
+  describe("reduce — error", () => {
+    it("clears streamingText, sets error, and preserves finalText and proactive", () => {
+      const state = {
+        ...initialStreamState,
+        streamingText: "partial",
+        finalText: "kept final",
+        proactive: [{ message: "p1" }],
+      };
+      const next = reduce(state, { type: "error", message: "boom" });
+      expect(next.streamingText).toBeNull();
+      expect(next.error).toBe("boom");
+      expect(next.finalText).toBe("kept final");
+      expect(next.proactive).toEqual([{ message: "p1" }]);
+    });
+
+    it("returns a new object reference and does not mutate input", () => {
+      const state = { ...initialStreamState, streamingText: "partial" };
+      const before = { ...state };
+      const next = reduce(state, { type: "error", message: "boom" });
+      expect(next).not.toBe(state);
+      expect(state).toEqual(before);
+    });
+  });
+
+  describe("reduce — proactive", () => {
+    it("appends a message-only entry without conversationId key", () => {
+      const next = reduce(initialStreamState, {
+        type: "proactive",
+        message: "ping",
+      });
+      expect(next.proactive).toEqual([{ message: "ping" }]);
+      expect(next.proactive[0]).not.toHaveProperty("conversationId");
+    });
+
+    it("appends an entry with conversationId when present on the frame", () => {
+      const next = reduce(initialStreamState, {
+        type: "proactive",
+        message: "ping",
+        conversationId: "c5",
+      });
+      expect(next.proactive).toEqual([
+        { message: "ping", conversationId: "c5" },
+      ]);
+    });
+
+    it("returns a new proactive array reference and does not mutate the input array", () => {
+      const arr = [{ message: "first" }];
+      const state = { ...initialStreamState, proactive: arr };
+      const next = reduce(state, { type: "proactive", message: "second" });
+      expect(next.proactive).not.toBe(arr);
+      expect(arr).toHaveLength(1);
+      expect(next.proactive).toHaveLength(2);
+      expect(next).not.toBe(state);
+    });
+
+    it("leaves all other fields unchanged", () => {
+      const state = {
+        ...initialStreamState,
+        streamingText: "s",
+        finalText: "f",
+        conversationId: "c",
+        done: true,
+        error: "e",
+      };
+      const next = reduce(state, { type: "proactive", message: "ping" });
+      expect(next.streamingText).toBe("s");
+      expect(next.finalText).toBe("f");
+      expect(next.conversationId).toBe("c");
+      expect(next.done).toBe(true);
+      expect(next.error).toBe("e");
+    });
+
+    it("accumulates two consecutive proactive frames in order", () => {
+      const s1 = reduce(initialStreamState, {
+        type: "proactive",
+        message: "one",
+      });
+      const s2 = reduce(s1, { type: "proactive", message: "two" });
+      expect(s2.proactive).toEqual([{ message: "one" }, { message: "two" }]);
+    });
+  });
+
+  describe("reduce — full sequence", () => {
+    it("folds conversation, tokens, then done", () => {
+      const frames = [
+        { type: "conversation", conversationId: "conv-1" } as const,
+        { type: "token", text: "Hel" } as const,
+        { type: "token", text: "lo " } as const,
+        { type: "token", text: "world" } as const,
+        { type: "done", conversationId: "conv-1", fullText: "Hello world" } as const,
+      ];
+      const final = frames.reduce(reduce, initialStreamState);
+      expect(final.finalText).toBe("Hello world");
+      expect(final.streamingText).toBeNull();
+      expect(final.done).toBe(true);
+      expect(final.conversationId).toBe("conv-1");
+      expect(final.error).toBeNull();
+    });
+  });
+
+  describe("resetTurn", () => {
+    it("clears turn fields and preserves conversationId and proactive contents", () => {
+      const proactive = [{ message: "p1" }, { message: "p2" }];
+      const state = {
+        streamingText: "partial",
+        finalText: "final",
+        conversationId: "c7",
+        done: true,
+        error: "boom",
+        proactive,
+      };
+      const next = resetTurn(state);
+      expect(next).toEqual({
+        streamingText: null,
+        finalText: null,
+        conversationId: "c7",
+        done: false,
+        error: null,
+        proactive,
+      });
+      expect(next.proactive).toEqual(proactive);
+    });
+
+    it("returns a new object reference and does not mutate input", () => {
+      const state = {
+        streamingText: "partial",
+        finalText: "final",
+        conversationId: "c7",
+        done: true,
+        error: "boom",
+        proactive: [{ message: "p1" }],
+      };
+      const before = JSON.parse(JSON.stringify(state));
+      const next = resetTurn(state);
+      expect(next).not.toBe(state);
+      expect(state).toEqual(before);
+    });
+  });
+});

--- a/apps/mobile/src/lib/agent-socket-protocol.ts
+++ b/apps/mobile/src/lib/agent-socket-protocol.ts
@@ -1,0 +1,244 @@
+/**
+ * Pure, framework-free protocol + state logic for the agents-worker WebSocket
+ * chat transport (#199). NO React/React Native imports — this module is the
+ * unit-tested heart of the mobile streaming path and must stay portable.
+ *
+ * It mirrors the wire protocol the agents Worker speaks (apps/agents/src/chat.ts
+ * for chat-turn frames + apps/agents/src/index.ts `deliverProactive` for the
+ * out-of-turn `proactive` broadcast) and the web client that already consumes it
+ * (apps/web/lib/use-agent-chat.ts).
+ *
+ * ── WebSocket protocol ────────────────────────────────────────────────────
+ * Client → server (one JSON frame per user turn):
+ *   { type: "chat", conversationId: string | null, message: string,
+ *     userContext?: string }
+ *   (userContext is IGNORED server-side for Coomander — context is rendered from
+ *    the user's live ops data — but the field is kept for template parity.)
+ *
+ * Server → client (multiple frames):
+ *   { type: "conversation"; conversationId }          // always "coomander"
+ *   { type: "token"; text }                            // streamed model delta
+ *   { type: "done"; conversationId; fullText }         // final, tag-stripped
+ *   { type: "error"; message }                         // user-safe failure
+ *   { type: "proactive"; message; conversationId? }    // agent-initiated nudge
+ *
+ * The hook (use-agent-socket.ts) wraps a raw RN WebSocket, parses each frame
+ * with `parseServerFrame`, and folds it into `StreamState` via `reduce`.
+ */
+
+/** Coomander has one unified thread per user; this is the sentinel id. */
+export const COOMANDER_CONVERSATION_ID = "coomander";
+
+/** The Cloudflare Flagship key that gates the WebSocket transport (#192). */
+export const AGENTS_CHAT_FLAG = "coomander-agents-chat";
+
+/**
+ * The agents Worker routes `/agents/<kebab-binding>/<name>`. The binding is
+ * `AppAgent` → `app-agent`; the Worker ignores the client-supplied name and
+ * routes by the validated session userId, so the name is cosmetic.
+ */
+export const AGENT_PATH_PREFIX = "/agents/app-agent";
+
+// ── Wire frames ─────────────────────────────────────────────────────────────
+
+/** A user turn sent client → server. */
+export interface ClientFrame {
+  type: "chat";
+  conversationId: string | null;
+  message: string;
+  userContext?: string;
+}
+
+/** Any frame the server may send back. */
+export type ServerFrame =
+  | { type: "conversation"; conversationId: string }
+  | { type: "token"; text: string }
+  | { type: "done"; conversationId: string; fullText: string }
+  | { type: "error"; message: string }
+  | { type: "proactive"; message: string; conversationId?: string };
+
+/**
+ * Parse a raw WebSocket payload into a typed ServerFrame, or null if it isn't a
+ * well-formed frame. Defensive by contract: it NEVER throws — malformed JSON,
+ * non-string payloads (Blob/ArrayBuffer), wrong/missing `type`, or missing
+ * required fields all return null so the caller can simply ignore them.
+ */
+export function parseServerFrame(data: unknown): ServerFrame | null {
+  if (typeof data !== "string") return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+
+  const o = parsed as Record<string, unknown>;
+  switch (o.type) {
+    case "conversation":
+      return typeof o.conversationId === "string"
+        ? { type: "conversation", conversationId: o.conversationId }
+        : null;
+    case "token":
+      return typeof o.text === "string" ? { type: "token", text: o.text } : null;
+    case "done":
+      return typeof o.conversationId === "string" && typeof o.fullText === "string"
+        ? { type: "done", conversationId: o.conversationId, fullText: o.fullText }
+        : null;
+    case "error":
+      return typeof o.message === "string" ? { type: "error", message: o.message } : null;
+    case "proactive":
+      return typeof o.message === "string"
+        ? {
+            type: "proactive",
+            message: o.message,
+            ...(typeof o.conversationId === "string"
+              ? { conversationId: o.conversationId }
+              : {}),
+          }
+        : null;
+    default:
+      return null;
+  }
+}
+
+/** Serialize a user turn into the JSON `chat` frame the Worker expects. */
+export function encodeChatFrame(args: {
+  conversationId: string | null;
+  message: string;
+  userContext?: string;
+}): string {
+  const frame: ClientFrame = {
+    type: "chat",
+    conversationId: args.conversationId,
+    message: args.message,
+    ...(args.userContext !== undefined ? { userContext: args.userContext } : {}),
+  };
+  return JSON.stringify(frame);
+}
+
+/**
+ * Build the WebSocket URL from the HTTP API base: swap the scheme
+ * (http→ws / https→wss) and append the agent instance path. `name` is cosmetic
+ * (the Worker routes by validated session), defaulting to "me".
+ */
+export function buildWsUrl(apiUrl: string, name = "me"): string {
+  const base = apiUrl.replace(/\/+$/, "");
+  // Normalize the scheme to a lowercase ws/wss (literal replacements, so an
+  // uppercase HTTPS:// can't leak a stray uppercase letter into the scheme).
+  // `https` is checked first; `^http:` won't match `https:` anyway (no colon
+  // after "http"), so the order is just for clarity.
+  const wsBase = base.replace(/^https:/i, "wss:").replace(/^http:/i, "ws:");
+  return `${wsBase}${AGENT_PATH_PREFIX}/${encodeURIComponent(name)}`;
+}
+
+/**
+ * Decide whether a turn should go over the WebSocket. The POST/SSE path is the
+ * universal fallback, so this is true ONLY when the flag is on, the user is
+ * entitled (when chat is gated — `undefined` means "not gated"), and the socket
+ * is actually open right now. Any false → caller falls back to POST/SSE.
+ */
+export function shouldUseSocket(args: {
+  flagEnabled: boolean;
+  entitled?: boolean;
+  socketReady: boolean;
+}): boolean {
+  if (!args.flagEnabled) return false;
+  if (args.entitled === false) return false;
+  return args.socketReady;
+}
+
+// ── Stream reducer (the testable heart) ──────────────────────────────────────
+
+/** An agent-initiated message pushed outside any user turn. */
+export interface ProactiveEvent {
+  message: string;
+  conversationId?: string;
+}
+
+/**
+ * The evolving state of the live WebSocket stream for the current turn, plus the
+ * out-of-turn proactive queue. The screen renders the in-progress assistant
+ * bubble from `streamingText` (then `finalText` on done) and reacts to
+ * `done` / `error` / `proactive`.
+ */
+export interface StreamState {
+  /** Tokens accumulated for the in-flight assistant turn (null when idle). */
+  streamingText: string | null;
+  /** The final, tag-clean assistant text once `done` arrives (null until then). */
+  finalText: string | null;
+  /** Conversation id tracked from `conversation` / `done` frames. */
+  conversationId: string | null;
+  /** True once the in-flight turn finishes (a `done` frame arrived). */
+  done: boolean;
+  /** A user-safe error surfaced this turn (null = none). */
+  error: string | null;
+  /** Proactive (agent-initiated) messages, in arrival order (append-only). */
+  proactive: ProactiveEvent[];
+}
+
+export const initialStreamState: StreamState = {
+  streamingText: null,
+  finalText: null,
+  conversationId: null,
+  done: false,
+  error: null,
+  proactive: [],
+};
+
+/**
+ * Fold one server frame into the stream state. Pure and immutable — always
+ * returns a NEW object (and a new `proactive` array when it changes); never
+ * mutates the input. Unknown frame types return the same state reference.
+ *
+ *   conversation → track conversationId (no text change)
+ *   token        → append the delta to streamingText (null treated as "")
+ *   done         → finalize: clear streamingText, set finalText + conversationId,
+ *                  mark done
+ *   error        → surface the message, clear streamingText
+ *   proactive    → append to the proactive queue
+ */
+export function reduce(state: StreamState, frame: ServerFrame): StreamState {
+  switch (frame.type) {
+    case "conversation":
+      return { ...state, conversationId: frame.conversationId };
+    case "token":
+      return { ...state, streamingText: (state.streamingText ?? "") + frame.text };
+    case "done":
+      return {
+        ...state,
+        streamingText: null,
+        finalText: frame.fullText,
+        conversationId: frame.conversationId,
+        done: true,
+      };
+    case "error":
+      return { ...state, streamingText: null, error: frame.message };
+    case "proactive":
+      return {
+        ...state,
+        proactive: [
+          ...state.proactive,
+          {
+            message: frame.message,
+            ...(frame.conversationId !== undefined
+              ? { conversationId: frame.conversationId }
+              : {}),
+          },
+        ],
+      };
+    default:
+      return state;
+  }
+}
+
+/**
+ * Reset the per-turn fields before sending a new turn (or after handling a
+ * finished/errored one). Preserves `conversationId` and the append-only
+ * `proactive` queue (which the screen drains by tracking a processed index, so
+ * clearing it here would desync that index).
+ */
+export function resetTurn(state: StreamState): StreamState {
+  return { ...state, streamingText: null, finalText: null, done: false, error: null };
+}

--- a/apps/mobile/src/lib/use-agent-socket.ts
+++ b/apps/mobile/src/lib/use-agent-socket.ts
@@ -1,0 +1,253 @@
+/**
+ * Raw React Native WebSocket transport to the user's AppAgent (#199).
+ *
+ * This is the mobile counterpart to apps/web/lib/use-agent-chat.ts. The web uses
+ * `agents/react` (partysocket) because browsers send the Better Auth session
+ * cookie automatically — but the browser WebSocket API cannot set request
+ * headers. The agents Worker authenticates the WS UPGRADE with the session
+ * cookie, so on mobile we MUST use a raw `WebSocket` whose 3rd options arg
+ * injects `Cookie: authClient.getCookie()`. partysocket would add a
+ * browser-oriented dep and still couldn't set that header — hence a plain socket.
+ *
+ * Routing facts that make a plain raw socket work (no partysocket query params):
+ *   - partyserver's router generates a connection id when `_pk` is absent, so a
+ *     bare upgrade to /agents/app-agent/<name> routes to the DO and fires
+ *     onConnect.
+ *   - The Worker ignores the client name and routes by validated session userId;
+ *     "me" is cosmetic.
+ *
+ * The hook stays thin: it parses each frame with `parseServerFrame` and forwards
+ * it via `onFrame` (the screen folds frames into StreamState with `reduce`).
+ * The POST/SSE path (lib/api.ts `streamMessage`) remains the universal fallback
+ * whenever this socket isn't open.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { authClient, API_URL } from "./auth-client";
+import {
+  AGENTS_CHAT_FLAG,
+  buildWsUrl,
+  encodeChatFrame,
+  parseServerFrame,
+  type ServerFrame,
+} from "./agent-socket-protocol";
+
+export type SocketStatus = "connecting" | "open" | "closed";
+
+export interface UseAgentSocketArgs {
+  /** Open the socket only when true (flag on + ops enabled). False → never connect. */
+  enabled: boolean;
+  /** Invoked with every parsed server frame. */
+  onFrame: (frame: ServerFrame) => void;
+  /** Invoked on connection lifecycle transitions. */
+  onStatusChange?: (status: SocketStatus) => void;
+}
+
+export interface AgentSocketHandle {
+  /** True while the socket is open and ready to send. */
+  ready: () => boolean;
+  /** Send a user turn over the socket; false if the socket isn't open. */
+  send: (args: {
+    conversationId: string | null;
+    message: string;
+    userContext?: string;
+  }) => boolean;
+}
+
+/** Capped exponential backoff for reconnects. */
+const BASE_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+
+/** WebSocket close code the agents Worker uses for auth failures (#199). */
+const WS_CLOSE_AUTH = 1008;
+
+/**
+ * RN's WebSocket constructor accepts a 3rd `options` arg with `headers`
+ * (lib.dom's type only declares 2 args), so widen it locally. The instance is
+ * still the lib.dom WebSocket type, which covers our event/handler usage.
+ */
+const RNWebSocket = WebSocket as unknown as {
+  new (
+    url: string,
+    protocols: string | string[] | null,
+    options: { headers: Record<string, string> },
+  ): WebSocket;
+};
+
+export function useAgentSocket({
+  enabled,
+  onFrame,
+  onStatusChange,
+}: UseAgentSocketArgs): AgentSocketHandle {
+  // Keep the latest callbacks in refs so the socket handlers always call the
+  // current ones without making the connect effect depend on (and tear down for)
+  // changing callback identities.
+  const onFrameRef = useRef(onFrame);
+  const onStatusRef = useRef(onStatusChange);
+  useEffect(() => {
+    onFrameRef.current = onFrame;
+  });
+  useEffect(() => {
+    onStatusRef.current = onStatusChange;
+  });
+
+  const socketRef = useRef<WebSocket | null>(null);
+  const openRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let attempt = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    // Set when an auth close (1008) tells us not to keep hammering the Worker.
+    let stopped = false;
+
+    const clearTimer = () => {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+    };
+
+    const scheduleReconnect = () => {
+      if (cancelled || stopped) return;
+      const delay = Math.min(
+        BASE_RECONNECT_DELAY_MS * 2 ** attempt,
+        MAX_RECONNECT_DELAY_MS,
+      );
+      attempt += 1;
+      clearTimer();
+      reconnectTimer = setTimeout(connect, delay);
+    };
+
+    function connect() {
+      if (cancelled || stopped) return;
+
+      const cookie = authClient.getCookie();
+      if (!cookie) {
+        // Not signed in (or cookie not yet stored) — don't attempt a doomed
+        // upgrade; the POST/SSE path stays the fallback. A later mount (after
+        // sign-in) re-runs this effect.
+        stopped = true;
+        return;
+      }
+
+      let ws: WebSocket;
+      try {
+        onStatusRef.current?.("connecting");
+        ws = new RNWebSocket(buildWsUrl(API_URL), null, {
+          // Cookie ONLY — no Origin. The Worker validates the session with a GET
+          // to /api/auth/get-session, which Better Auth does NOT CSRF-check, so
+          // the upgrade needs only the cookie (sending Origin is explicitly out
+          // of scope per #199).
+          headers: { Cookie: cookie },
+        });
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+      socketRef.current = ws;
+
+      ws.onopen = () => {
+        if (cancelled) {
+          try {
+            ws.close();
+          } catch {
+            // ignore
+          }
+          return;
+        }
+        openRef.current = true;
+        attempt = 0;
+        onStatusRef.current?.("open");
+      };
+
+      ws.onmessage = (event: MessageEvent) => {
+        const frame = parseServerFrame(event.data);
+        if (frame) onFrameRef.current(frame);
+      };
+
+      // onerror is followed by onclose in RN; do the cleanup/reconnect there so
+      // we don't double-schedule.
+      ws.onerror = () => {};
+
+      ws.onclose = (event: CloseEvent) => {
+        openRef.current = false;
+        if (socketRef.current === ws) socketRef.current = null;
+        onStatusRef.current?.("closed");
+        if (event?.code === WS_CLOSE_AUTH) {
+          // Session invalid/expired — reconnecting would just loop. Stop until
+          // the effect re-runs (e.g. flag/ops toggled or screen remount).
+          stopped = true;
+          return;
+        }
+        scheduleReconnect();
+      };
+    }
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      stopped = true;
+      clearTimer();
+      openRef.current = false;
+      const ws = socketRef.current;
+      socketRef.current = null;
+      if (ws) {
+        // Detach handlers so a late close/message can't fire callbacks after
+        // unmount, then close.
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onerror = null;
+        ws.onclose = null;
+        try {
+          ws.close();
+        } catch {
+          // ignore
+        }
+      }
+    };
+  }, [enabled]);
+
+  const send = useCallback<AgentSocketHandle["send"]>((args) => {
+    const ws = socketRef.current;
+    if (!openRef.current || !ws) return false;
+    try {
+      ws.send(encodeChatFrame(args));
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  const ready = useCallback(() => openRef.current, []);
+
+  return { ready, send };
+}
+
+/**
+ * Resolve the `coomander-agents-chat` flag from the web app's `GET /api/flags`.
+ * Attaches the session cookie + Origin like the rest of the mobile API client.
+ * Returns false on any failure (endpoint down, network error, non-OK) so the app
+ * stays on the POST/SSE path — the flag-off default is always safe.
+ */
+export async function fetchAgentChatFlag(apiUrl: string = API_URL): Promise<boolean> {
+  try {
+    const cookie = authClient.getCookie();
+    const res = await fetch(`${apiUrl}/api/flags`, {
+      headers: {
+        Accept: "application/json",
+        Origin: apiUrl,
+        ...(cookie ? { Cookie: cookie } : {}),
+      },
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { flags?: Record<string, unknown> } | null;
+    return Boolean(data?.flags?.[AGENTS_CHAT_FLAG]);
+  } catch {
+    return false;
+  }
+}

--- a/changelogs/2026-06-18-mobile-agents-websocket.md
+++ b/changelogs/2026-06-18-mobile-agents-websocket.md
@@ -1,0 +1,56 @@
+---
+date: 2026-06-18
+scope: [mobile]
+category: feature
+files_changed:
+  - apps/mobile/src/lib/agent-socket-protocol.ts
+  - apps/mobile/src/lib/use-agent-socket.ts
+  - apps/mobile/src/lib/__tests__/agent-socket-protocol.test.ts
+  - apps/mobile/src/app/(app)/index.tsx
+requires_migration: false
+requires_env_vars: []
+breaking: false
+---
+
+## Mobile: stream chat over the agents-worker WebSocket (POST/SSE fallback)
+
+The Expo chat screen now streams the assistant reply **token-by-token over the
+agents Worker WebSocket** when the `coomander-agents-chat` flag is on — the same
+transport the web app uses (#192) — while the existing POST/SSE path
+(`lib/api.ts` `streamMessage`) stays the universal fallback. Flag-gated, no
+regressions.
+
+### Why a raw RN WebSocket (not `agents/react` / partysocket)
+
+The agents Worker authenticates the WS **upgrade** with the Better Auth session
+cookie. Browsers send it automatically (so web uses partysocket), but the
+browser WebSocket API can't set request headers. React Native's
+`new WebSocket(url, protocols, { headers })` CAN, so the hook injects
+`Cookie: authClient.getCookie()` on the upgrade — **cookie only, no Origin**
+(the Worker validates via a GET to `/api/auth/get-session`, which isn't
+CSRF-checked). No `partysocket`/`agents` dependency added to the app.
+
+### New files
+
+- `lib/agent-socket-protocol.ts` — pure, framework-free protocol + state core
+  (the unit-tested heart): `parseServerFrame` (defensive, never throws),
+  `encodeChatFrame`, `buildWsUrl` (http→ws / https→wss + `/agents/app-agent/me`),
+  `shouldUseSocket`, and the immutable stream `reduce` /`resetTurn`
+  (token→append, done→finalize, error→surface, proactive→insert,
+  conversation→track).
+- `lib/use-agent-socket.ts` — raw RN WebSocket hook (`{ ready, send }`): opens
+  only when enabled, capped-backoff reconnect, stops on a `1008` (auth) close,
+  forwards parsed frames via `onFrame`. Plus `fetchAgentChatFlag()` reading
+  `GET /api/flags` (defaults false on failure).
+- `lib/__tests__/agent-socket-protocol.test.ts` — 78 spec-driven unit tests for
+  the pure module (frame parse/validation, URL build, fallback selection, every
+  reducer transition + immutability).
+
+### Screen integration (`app/(app)/index.tsx`)
+
+Resolves the flag on mount; opens the socket only when flag-on **and** ops is
+enabled; streams tokens into a live assistant bubble; on `done` reloads the
+canonical thread then drops the live bubble (shows final text until the reload
+replaces it → no flicker); surfaces `error` frames and proactive messages;
+keeps the optimistic user bubble on error; and falls back to POST/SSE whenever
+the socket isn't open.


### PR DESCRIPTION
Closes #199

## What

Brings the web app's **agents-worker WebSocket streaming** down to the Expo mobile chat screen so the assistant reply streams **token-by-token**, flag-gated on `coomander-agents-chat`, with the existing **POST/SSE path preserved as the universal fallback**. Mobile-client-only — no changes to the agents worker, its WS protocol, or the web client.

## The crux: raw RN WebSocket (not `agents/react` / partysocket)

The agents Worker authenticates the WS **upgrade** with the Better Auth session cookie. Browsers send it automatically (web uses partysocket), but the browser WebSocket API can't set request headers. React Native's `new WebSocket(url, protocols, { headers })` CAN, so the hook injects `Cookie: authClient.getCookie()` on the upgrade — **cookie only, no Origin** (the Worker validates via a GET to `/api/auth/get-session`, which isn't CSRF-checked). No `partysocket`/`agents` dependency added to the app.

URL: `EXPO_PUBLIC_API_URL` with `http→ws` / `https→wss`, then `/agents/app-agent/me` (name cosmetic — the Worker routes by validated session userId).

## Files (3 mobile-only + tests)

- **`lib/agent-socket-protocol.ts`** — pure, framework-free protocol + state core (the unit-tested heart): `parseServerFrame` (defensive, never throws), `encodeChatFrame`, `buildWsUrl`, `shouldUseSocket`, and the immutable stream `reduce`/`resetTurn` (token→append, done→finalize, error→surface, proactive→insert, conversation→track).
- **`lib/use-agent-socket.ts`** — raw RN WebSocket hook (`{ ready, send }`): opens only when enabled, injects the Cookie header, capped-backoff reconnect, **stops reconnecting on a `1008` (auth) close**, forwards parsed frames via `onFrame`. Plus `fetchAgentChatFlag()` reading `GET /api/flags` (defaults false on failure).
- **`lib/__tests__/agent-socket-protocol.test.ts`** — 78 spec-driven unit tests (written by a **separate subagent** against the spec, not the implementation). They caught a real `buildWsUrl` case-sensitivity bug, which was fixed in the implementation.
- **`app/(app)/index.tsx`** — screen integration: resolves the flag, opens the socket only when flag-on **and** ops enabled, streams tokens into a live bubble, reloads the canonical thread on `done` (shows final text until the reload replaces it → no flicker), surfaces `error`/`proactive` frames, keeps the optimistic user bubble on error, and falls back to POST/SSE whenever the socket isn't open.

## Verification

- `npm run typecheck` (mobile) — clean
- `npm run lint` (mobile) — 0 errors (2 pre-existing warnings, unrelated)
- `npx jest` (mobile) — **78/78 passing**
- On-device token-by-token vs all-at-once (= fallback) behavior → tracked in the linked QA issue (live-socket behaviors can only be verified on a real build).

## Out of scope (per #199)

No `partysocket`/`agents` dep added; POST/SSE fallback unchanged; no `Origin` header on the upgrade; single-thread assumption confirmed in `apps/agents/src/chat.ts` (`conversationId = "coomander"`).

QA: #201
