### PR TITLE
Release: enable AI Gateway routing + usage dashboard

### DIFF
--- a/apps/agents/wrangler.toml
+++ b/apps/agents/wrangler.toml
@@ -77,10 +77,11 @@ routes = [
 WEB_ORIGIN = "https://coomander.com"
 # AI Gateway routing — usage/cost analytics for the agent chatbot (#203, mirrors
 # the app worker). AI_GATEWAY_TOKEN (authenticated gateway) is a SECRET set via
-# `wrangler secret put AI_GATEWAY_TOKEN --env production`. Leave AI_GATEWAY_ID
-# commented until a gateway exists → direct Anthropic.
+# `wrangler secret put AI_GATEWAY_TOKEN --env production`. The coomander-gateway
+# (unauthenticated, caching off) routes Claude through Cloudflare AI Gateway for
+# usage/cost analytics (#203). Dev (top-level [vars]) stays direct.
 CLOUDFLARE_ACCOUNT_ID = "1ed6d9117731a48060db43fabbf1a468"
-# AI_GATEWAY_ID = "coomander-gateway"
+AI_GATEWAY_ID = "coomander-gateway"
 
 # Service binding agents → app worker. Session validation + persistence + the
 # internal-secret routes go through this, never a public HTTP round-trip.

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -63,10 +63,10 @@ FLAG_COOMANDER_AGENTS_CHAT = "true"
 # usage/cost analytics + caching. AI_GATEWAY_TOKEN (authenticated gateway) is a
 # SECRET: `wrangler secret put AI_GATEWAY_TOKEN`. If AI_GATEWAY_ID is unset / the
 # token is missing, AI calls fall back to direct Anthropic — no behavior change.
-# Left commented so the default deploy routes direct; set it to enable the
-# /admin/ai-usage dashboard (which also needs CF_ANALYTICS_API_TOKEN + the
-# CLOUDFLARE_ACCOUNT_ID above, with the "Account Analytics: Read" grant).
-# AI_GATEWAY_ID = "coomander-gateway"
+# Set to the coomander-gateway so the /admin/ai-usage dashboard queries it
+# (also needs the CF_ANALYTICS_API_TOKEN secret + the CLOUDFLARE_ACCOUNT_ID
+# above, with the "Account Analytics: Read" grant).
+AI_GATEWAY_ID = "coomander-gateway"
 #
 # NOTE: the web worker intentionally has NO [ai] binding. Workers AI (if added
 # later) runs on the AGENTS worker (apps/agents), which would declare its own

--- a/changelogs/2026-06-21-ai-gateway-enabled.md
+++ b/changelogs/2026-06-21-ai-gateway-enabled.md
@@ -1,0 +1,31 @@
+---
+date: 2026-06-21
+scope: [node, agents]
+category: feature
+files_changed:
+  - apps/web/wrangler.toml
+  - apps/agents/wrangler.toml
+requires_migration: false
+requires_env_vars: [CF_ANALYTICS_API_TOKEN]
+breaking: false
+---
+
+## Enable Cloudflare AI Gateway routing + the AI usage dashboard
+
+Created the `coomander-gateway` Cloudflare AI Gateway (unauthenticated, caching
+off, no rate limiting) and set `AI_GATEWAY_ID = "coomander-gateway"` on the web
+worker (`[vars]`) and the agents worker (`[env.production.vars]`).
+
+- **Claude (Anthropic) chat now routes through the gateway in prod**, so per-model
+  and per-user usage + cost are recorded and surfaced at `/admin/ai-usage`.
+- The dashboard reads gateway analytics via the **`CF_ANALYTICS_API_TOKEN`** secret
+  (a Cloudflare API token with **Account Analytics: Read**), set on the web worker.
+- **Caching is off** (`cache_ttl=0`) so the chat never returns stale replies.
+- **Dev stays direct** — the agents top-level `[vars]` `AI_GATEWAY_ID` is left unset,
+  so local/dev chat doesn't pollute the prod gateway analytics.
+- Workers AI open models still run via the `[ai]` binding (not the gateway); the
+  gateway tracks the Claude/Anthropic tier.
+
+Downstream projects set their own gateway name + `CF_ANALYTICS_API_TOKEN`; if
+`AI_GATEWAY_ID` is unset, AI calls fall back to direct Anthropic (no behavior
+change) and the dashboard shows a graceful empty-state.


### PR DESCRIPTION
Enables coomander-gateway routing (AI_GATEWAY_ID) on web + agents; web reads gateway analytics via CF_ANALYTICS_API_TOKEN (secret already set). Code/config only — no migration.