### PR TITLE
Release v0.2.0 — cadence-ping frequency UI + "off" setting

### DIFF
--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coomander/agents",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Coomander sidecar agent Worker — Coomander as a per-user stateful agent on the Cloudflare Agents SDK",
   "scripts": {

--- a/apps/web/app/api/coomander/settings/route.ts
+++ b/apps/web/app/api/coomander/settings/route.ts
@@ -53,7 +53,7 @@ export async function PATCH(request: Request) {
 
     if (body.nagFrequency !== undefined) {
       if (!isValidNagFrequency(body.nagFrequency)) {
-        throw new BadRequestError("nagFrequency must be one of: tight, moderate, light");
+        throw new BadRequestError("nagFrequency must be one of: off, light, moderate, tight");
       }
       patch.nagFrequency = body.nagFrequency;
     }

--- a/apps/web/app/app/cadence/page.tsx
+++ b/apps/web/app/app/cadence/page.tsx
@@ -24,6 +24,15 @@ const CONTENT_STATES = ["drafted", "shot", "approved", "uploaded_to_edit", "edit
 const CADENCE_KINDS = ["daily", "weekly", "window", "daily_vlog_buffer"] as const;
 const PILLAR_KINDS = ["content", "wall", "procurement", "engagement", "admin"] as const;
 
+// Cadence-ping presets (nag frequency). Ordered least → most frequent; mirrors
+// NAG_FREQUENCIES / PRESET_SLOTS server-side. "off" silences all scheduled pings.
+const NAG_OPTIONS: { value: string; label: string; desc: string }[] = [
+  { value: "off", label: "Off", desc: "No scheduled pings. You can still chat anytime." },
+  { value: "light", label: "Light", desc: "Morning and evening only." },
+  { value: "moderate", label: "Moderate", desc: "Morning, midday, and evening." },
+  { value: "tight", label: "Tight", desc: "All four daily touchpoints (default)." },
+];
+
 type Json = Record<string, unknown>;
 
 // Minimal shapes (the API returns more; we read what we render).
@@ -77,6 +86,8 @@ export default function CoomanderPage() {
   const [bannerDismissed, setBannerDismissed] = useState(true);
   const [enabling, setEnabling] = useState(false);
   const [latestReviewWeek, setLatestReviewWeek] = useState<string | null>(null);
+  const [nagFrequency, setNagFrequency] = useState<string>("tight");
+  const [savingNag, setSavingNag] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -92,7 +103,9 @@ export default function CoomanderPage() {
       ]);
       setModel(t.model as TodayModel);
       setContent((c.content as ContentItem[]) ?? []);
-      setBannerDismissed(((s.settings as { defaultsBannerDismissedAt: number | null }).defaultsBannerDismissedAt) != null);
+      const settings = s.settings as { defaultsBannerDismissedAt: number | null; nagFrequency: string };
+      setBannerDismissed(settings.defaultsBannerDismissedAt != null);
+      setNagFrequency(settings.nagFrequency ?? "tight");
       const rev = lr.review as { week_ending: string } | null;
       setLatestReviewWeek(rev?.week_ending ?? null);
     } catch (e) {
@@ -113,6 +126,22 @@ export default function CoomanderPage() {
   const dismissBanner = async () => {
     setBannerDismissed(true);
     try { await api("PATCH", "/api/coomander/settings", { dismissBanner: true }); } catch { /* best effort */ }
+  };
+
+  const saveNagFrequency = async (value: string) => {
+    if (value === nagFrequency || savingNag) return;
+    const prev = nagFrequency;
+    setNagFrequency(value); // optimistic
+    setSavingNag(true);
+    try {
+      await api("PATCH", "/api/coomander/settings", { nagFrequency: value });
+      toast.success(value === "off" ? "Scheduled pings turned off" : `Cadence pings set to ${value}`);
+    } catch (e) {
+      setNagFrequency(prev); // revert on failure
+      toast.error((e as Error).message);
+    } finally {
+      setSavingNag(false);
+    }
   };
 
   const overallClass =
@@ -165,6 +194,38 @@ export default function CoomanderPage() {
               View latest weekly review ({latestReviewWeek}) →
             </Link>
           )}
+
+          {/* Cadence pings (nag frequency) */}
+          <Card title="Cadence pings">
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
+              How often Coomander checks in over Telegram. Choose <strong>Off</strong> to pause scheduled pings — chat still works anytime.
+            </p>
+            <div className="space-y-2">
+              {NAG_OPTIONS.map((o) => {
+                const active = nagFrequency === o.value;
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    onClick={() => saveNagFrequency(o.value)}
+                    disabled={savingNag}
+                    aria-pressed={active}
+                    className={`w-full text-left rounded-lg border p-3 transition disabled:opacity-60 ${
+                      active
+                        ? "border-blue-500 bg-blue-50 dark:bg-blue-950/40 ring-1 ring-blue-500"
+                        : "border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-gray-900 dark:text-gray-100">{o.label}</span>
+                      {active && <span className="text-xs font-medium text-blue-600 dark:text-blue-300">Current</span>}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{o.desc}</div>
+                  </button>
+                );
+              })}
+            </div>
+          </Card>
 
           {/* Pillars + beats */}
           <Card title="Cadence">

--- a/apps/web/lib/coomander/agent.ts
+++ b/apps/web/lib/coomander/agent.ts
@@ -37,11 +37,12 @@ import { eq } from "drizzle-orm";
 
 const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
 
-/** Which slots each nag preset is allowed to fire. */
+/** Which slots each nag preset is allowed to fire. "off" fires nothing. */
 export const PRESET_SLOTS: Record<NagFrequency, Slot[]> = {
-  tight: ["morning", "midday", "check", "evening"],
-  moderate: ["morning", "midday", "evening"],
+  off: [],
   light: ["morning", "evening"],
+  moderate: ["morning", "midday", "evening"],
+  tight: ["morning", "midday", "check", "evening"],
 };
 
 export interface PlanPingInput {
@@ -60,12 +61,16 @@ export interface PingPlan {
  * Pure decision: should we ping for this slot, given the user's nag preset?
  *
  * Rules (see docs/strategy/coomander-direction.md § Nag frequency):
+ *   - "off" silences everything: no slot fires.
  *   - The slot must be in the preset's allowed set (light = morning+evening,
  *     moderate = morning+midday+evening, tight = all four incl. the extra check).
  *   - On a "bad" day the midday and check touchpoints are suppressed (morning
  *     and evening anchors still fire).
  */
 export function planPing(input: PlanPingInput): PingPlan {
+  if (input.nagFrequency === "off") {
+    return { send: false, reason: "pings are off" };
+  }
   const allowed = PRESET_SLOTS[input.nagFrequency] ?? PRESET_SLOTS.tight;
   if (!allowed.includes(input.slot)) {
     return { send: false, reason: `${input.slot} is not in the '${input.nagFrequency}' preset` };

--- a/apps/web/lib/coomander/settings.ts
+++ b/apps/web/lib/coomander/settings.ts
@@ -17,10 +17,13 @@ import { getDb } from "@/lib/db";
 import { DEFAULT_TIMEZONE, todayLocal } from "./consistency";
 import { user as userT, coomanderSettings as settingsT } from "@/lib/schema";
 
-export type NagFrequency = "tight" | "moderate" | "light";
+// "off" fully silences scheduled pings (no slot fires); see PRESET_SLOTS /
+// planPing in agent.ts. It is opt-in — DEFAULT_NAG_FREQUENCY stays "tight".
+export type NagFrequency = "off" | "light" | "moderate" | "tight";
 export type PersonaMode = "light_companion" | "full_companion" | "operational";
 
-export const NAG_FREQUENCIES: NagFrequency[] = ["tight", "moderate", "light"];
+// Ordered least → most frequent (the cadence-pings UI renders them in this order).
+export const NAG_FREQUENCIES: NagFrequency[] = ["off", "light", "moderate", "tight"];
 export const PERSONA_MODES: PersonaMode[] = ["light_companion", "full_companion", "operational"];
 
 export const DEFAULT_NAG_FREQUENCY: NagFrequency = "tight";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coomander",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/tests/coomander-agent.test.ts
+++ b/apps/web/tests/coomander-agent.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from "vitest";
 import { planPing, PRESET_SLOTS } from "@/lib/coomander/agent";
 
 type Slot = "morning" | "midday" | "check" | "evening";
-type NagFrequency = "tight" | "moderate" | "light";
+type NagFrequency = "off" | "tight" | "moderate" | "light";
 
 const ALL_SLOTS: Slot[] = ["morning", "midday", "check", "evening"];
-const ALL_PRESETS: NagFrequency[] = ["tight", "moderate", "light"];
+const ALL_PRESETS: Exclude<NagFrequency, "off">[] = ["tight", "moderate", "light"];
 
 // Spec'd allowed-slot sets, declared here independently of the implementation.
-const ALLOWED: Record<NagFrequency, Slot[]> = {
+const ALLOWED: Record<Exclude<NagFrequency, "off">, Slot[]> = {
   tight: ["morning", "midday", "check", "evening"],
   moderate: ["morning", "midday", "evening"],
   light: ["morning", "evening"],
@@ -25,6 +25,52 @@ describe("PRESET_SLOTS", () => {
 
   it("light keeps only morning and evening", () => {
     expect(PRESET_SLOTS.light).toEqual(["morning", "evening"]);
+  });
+
+  it("off has no slots", () => {
+    expect(PRESET_SLOTS.off).toEqual([]);
+  });
+});
+
+describe("planPing — off preset silences everything", () => {
+  for (const slot of ALL_SLOTS) {
+    it(`off preset, ${slot} slot → send=false with reason "pings are off"`, () => {
+      const result = planPing({ slot, nagFrequency: "off" });
+      expect(result.send).toBe(false);
+      expect(result.reason).toBe("pings are off");
+    });
+  }
+
+  it("off suppresses every slot regardless of dayQuality 'good'", () => {
+    for (const slot of ALL_SLOTS) {
+      const result = planPing({ slot, nagFrequency: "off", dayQuality: "good" });
+      expect(result.send, `off/${slot} with good day`).toBe(false);
+      expect(result.reason, `off/${slot} with good day`).toBe("pings are off");
+    }
+  });
+
+  it("off suppresses every slot regardless of dayQuality 'bad'", () => {
+    for (const slot of ALL_SLOTS) {
+      const result = planPing({ slot, nagFrequency: "off", dayQuality: "bad" });
+      expect(result.send, `off/${slot} with bad day`).toBe(false);
+      expect(result.reason, `off/${slot} with bad day`).toBe("pings are off");
+    }
+  });
+
+  it("off suppresses every slot regardless of dayQuality null", () => {
+    for (const slot of ALL_SLOTS) {
+      const result = planPing({ slot, nagFrequency: "off", dayQuality: null });
+      expect(result.send, `off/${slot} with null day`).toBe(false);
+      expect(result.reason, `off/${slot} with null day`).toBe("pings are off");
+    }
+  });
+
+  it("off suppresses every slot when dayQuality is omitted", () => {
+    for (const slot of ALL_SLOTS) {
+      const result = planPing({ slot, nagFrequency: "off" });
+      expect(result.send, `off/${slot} with undefined day`).toBe(false);
+      expect(result.reason, `off/${slot} with undefined day`).toBe("pings are off");
+    }
   });
 });
 

--- a/apps/web/tests/coomander-settings.test.ts
+++ b/apps/web/tests/coomander-settings.test.ts
@@ -6,6 +6,7 @@ import {
   isValidPersonaMode,
   DEFAULT_NAG_FREQUENCY,
   DEFAULT_PERSONA_MODE,
+  NAG_FREQUENCIES,
 } from "@/lib/coomander/settings";
 
 describe("settings defaults", () => {
@@ -13,8 +14,24 @@ describe("settings defaults", () => {
     expect(DEFAULT_NAG_FREQUENCY).toBe("tight");
   });
 
+  it("DEFAULT_NAG_FREQUENCY is not 'off' (off is opt-in)", () => {
+    expect(DEFAULT_NAG_FREQUENCY).not.toBe("off");
+  });
+
   it("DEFAULT_PERSONA_MODE is 'light_companion'", () => {
     expect(DEFAULT_PERSONA_MODE).toBe("light_companion");
+  });
+});
+
+describe("NAG_FREQUENCIES", () => {
+  it("contains 'off'", () => {
+    expect(NAG_FREQUENCIES).toContain("off");
+  });
+
+  it("still contains light, moderate, and tight", () => {
+    expect(NAG_FREQUENCIES).toContain("light");
+    expect(NAG_FREQUENCIES).toContain("moderate");
+    expect(NAG_FREQUENCIES).toContain("tight");
   });
 });
 
@@ -23,6 +40,10 @@ describe("pickNagFrequency", () => {
     expect(pickNagFrequency({ nag_frequency: "tight" })).toBe("tight");
     expect(pickNagFrequency({ nag_frequency: "moderate" })).toBe("moderate");
     expect(pickNagFrequency({ nag_frequency: "light" })).toBe("light");
+  });
+
+  it("returns 'off' verbatim", () => {
+    expect(pickNagFrequency({ nag_frequency: "off" })).toBe("off");
   });
 
   it("falls back to default when row is undefined", () => {
@@ -71,6 +92,10 @@ describe("isValidNagFrequency", () => {
     expect(isValidNagFrequency("tight")).toBe(true);
     expect(isValidNagFrequency("moderate")).toBe(true);
     expect(isValidNagFrequency("light")).toBe(true);
+  });
+
+  it("true for 'off'", () => {
+    expect(isValidNagFrequency("off")).toBe(true);
   });
 
   it("false for invalid inputs", () => {

--- a/changelogs/2026-06-22-coomander-nag-frequency-off.md
+++ b/changelogs/2026-06-22-coomander-nag-frequency-off.md
@@ -1,0 +1,35 @@
+---
+date: 2026-06-22
+scope: [node]
+category: feature
+files_changed:
+  - apps/web/lib/coomander/settings.ts
+  - apps/web/lib/coomander/agent.ts
+  - apps/web/app/api/coomander/settings/route.ts
+  - apps/web/app/app/cadence/page.tsx
+requires_migration: false
+requires_env_vars: []
+breaking: false
+---
+
+## Wire up the cadence-ping frequency control + add an "off" setting
+
+The Coomander nag-frequency preset (`tight` / `moderate` / `light`) gated
+proactive Telegram pings server-side (`PRESET_SLOTS` + `planPing`), but had no
+user-facing control — `/app/cadence` never read or wrote it — and there was no
+way to fully silence pings short of a manual DB edit (the lowest preset,
+`light`, still fires morning + evening).
+
+- **New `off` frequency** — `PRESET_SLOTS.off = []` and an explicit `planPing`
+  early-return (`"pings are off"`) suppress every slot regardless of day
+  quality. `runAgentPing` already short-circuits on `!plan.send` before any
+  Anthropic/Telegram call, so `off` costs nothing.
+- **Wired the UI** — a "Cadence pings" card on `/app/cadence` (Off / Light /
+  Moderate / Tight) reflects the saved value and PATCHes
+  `/api/coomander/settings` on change (optimistic update, revert-on-error).
+- The settings route's 400 message now lists `off, light, moderate, tight`.
+
+`DEFAULT_NAG_FREQUENCY` stays `tight` (off is opt-in). No migration:
+`nag_frequency` is plain `TEXT` with no CHECK constraint. `off` pauses scheduled
+pings only — in-app + Telegram chat are unaffected (`coomanderEnabled`
+untouched).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coomander-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coomander-monorepo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -14,7 +14,7 @@
     },
     "apps/agents": {
       "name": "@coomander/agents",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.84",
         "@coomander/core": "*",
@@ -995,7 +995,7 @@
     },
     "apps/web": {
       "name": "coomander",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
@@ -37540,7 +37540,7 @@
     },
     "packages/core": {
       "name": "@coomander/core",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "better-auth": "1.4.18",
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coomander-monorepo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coomander/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Platform-agnostic core: Zod schemas, shared types, and a typed API client. No next/*, drizzle, better-sqlite3, react-dom, Node built-ins, or DOM globals (must run in React Native).",


### PR DESCRIPTION
## Release v0.2.0 → production

Promotes `develop` to `main` (prod deploys from `main` via Workers Builds).

### Included
- **#211 / #212** — Wire up the cadence-ping frequency control on `/app/cadence` and add an **`off`** setting that silences all scheduled Coomander pings (zero model cost; in-app + Telegram chat unaffected). No migration.
- Version bump `0.1.0 → 0.2.0` across the workspace.

### Verification (on develop)
- 56/56 unit tests pass; `tsc --noEmit` clean; `npm run build` succeeds.
- Live-QA'd locally: the control reflects the saved value and `off` persists across reload.

Live QA on prod to follow (QA issue #213).