### PR TITLE
Local Telegram dev: per-developer dev bot + Cloudflare Tunnel (#215)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,15 @@ DEV_PORT=3005
 # (verification, password reset) link back to the externally-reachable
 # domain, not localhost.
 APP_URL=https://coomander.gate-cardassian.ts.net
+
+# ── Local Telegram dev (opt-in, #215) ──────────────────────────────────
+# Only needed if you want inbound Telegram (the bot replying / the Connect
+# flow) to work against YOUR local dev server. Telegram allows one webhook per
+# bot, so each developer runs their OWN dev bot + their OWN Cloudflare named
+# tunnel. This token is for the `cloudflared` sidecar (started only with
+# `docker compose --profile telegram up`). Create a named tunnel in the
+# Cloudflare Zero Trust dashboard, scope its public hostname's ingress to the
+# /api/coomander/webhook path → http://localhost:3000, and paste its token here.
+# The dev bot token + webhook URL go in apps/web/.env.local. Full walkthrough:
+# README → "Local Telegram dev". Leave blank for normal (non-Telegram) dev.
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/README.md
+++ b/README.md
@@ -88,6 +88,51 @@ OAuth providers (Google, GitHub, Microsoft) need both URLs allow-listed:
 
 Set up via `/configure-sso` — it knows about both.
 
+## Local Telegram dev (per-developer bot + Cloudflare Tunnel)
+
+Coomander's Telegram inbound is **webhook-based** (`POST /api/coomander/webhook`), and **Telegram allows exactly one webhook URL per bot.** Production's `@coomander_bot` already owns it (→ `https://coomander.com/api/coomander/webhook`). So to use Telegram against *your* local dev server — the bot replying, and the **Connect Telegram** link flow — you run **your own dev bot** plus a **persistent Cloudflare Tunnel** to your machine.
+
+> Optional. Skip this entirely for normal dev — `docker compose up` works without it; only outbound features that *send* Telegram need a token, and inbound needs this tunnel.
+
+### One-time setup
+
+1. **Create a dev bot.** In Telegram, message [@BotFather](https://t.me/BotFather) → `/newbot` → name it (e.g. `Coomander Dev (you)`), username e.g. `coomander_dev_you_bot`. Save the **bot token** and the **@username**.
+
+2. **Create a Cloudflare named tunnel** (free; uses the existing `coomander.com` zone). In the [Zero Trust dashboard](https://one.dash.cloudflare.com) → **Networks → Tunnels → Create a tunnel** → *Cloudflared*:
+   - Name it `coomander-dev-<you>`; copy the **tunnel token**.
+   - Add a **Public Hostname**: subdomain `dev-<you>`, domain `coomander.com`, **Path** `api/coomander/webhook`, Service `HTTP` → `localhost:3000`. (Path-scoping keeps the rest of your dev server private; the catch-all stays a 404.)
+
+3. **Set env vars.**
+   - Repo-root `.env` (compose interpolation): `CLOUDFLARE_TUNNEL_TOKEN=<tunnel token>`
+   - `apps/web/.env.local`:
+     ```bash
+     MADDIE_TELEGRAM_BOT_TOKEN=<your dev bot token>
+     MADDIE_TELEGRAM_WEBHOOK_SECRET=$(openssl rand -hex 24)
+     COOMANDER_BOT_USERNAME=coomander_dev_you_bot         # so the Connect link points at YOUR dev bot
+     TELEGRAM_WEBHOOK_URL=https://dev-you.coomander.com/api/coomander/webhook
+     ```
+
+### Each session
+
+```bash
+# from apps/web — starts the normal stack PLUS the cloudflared sidecar
+npm run docker:dev:telegram          # = docker compose --profile dev --profile telegram up --build
+
+# register your dev bot's webhook at your tunnel (one-time per bot, or after changing the URL)
+npm run telegram:webhook -- set --yes
+npm run telegram:webhook -- info     # verify: url + 0 pending + no last_error
+```
+
+The `set` command prints the resolved bot `@username` first and **requires `--yes`** — a guard so you can't accidentally repoint prod's `@coomander_bot` (verify the username is your dev bot before confirming).
+
+Then open the app (localhost:3005 or the tailnet URL), go to the home/onboarding **Connect Telegram** card → tap the deep link (or send the code) to **your dev bot** → it links your local user. Now pings and replies flow through your machine.
+
+### Notes
+
+- **One webhook per bot** is why each developer needs their own bot — two people can't point the same bot at two tunnels.
+- `npm run telegram:webhook -- delete` clears your dev bot's webhook (e.g. before stepping away).
+- Never put `COOMANDER_TELEGRAM_DISABLED` in `.env.local` — it bakes into the prod bundle.
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -105,6 +150,11 @@ Set up via `/configure-sso` — it knows about both.
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | If using GitHub SSO | OAuth credentials. |
 | `ANTHROPIC_API_KEY` | If using AI chat | Claude API for the chat surface. |
 | `ELEVENLABS_API_KEY` | If using voice | ElevenLabs TTS (optional — chat falls back to text). |
+| `MADDIE_TELEGRAM_BOT_TOKEN` | If using Telegram | Bot token from @BotFather. Prod = `@coomander_bot`; local dev = your own dev bot (see "Local Telegram dev"). |
+| `MADDIE_TELEGRAM_WEBHOOK_SECRET` | If using Telegram inbound | Secret echoed on the inbound webhook; `openssl rand -hex 24`. |
+| `COOMANDER_BOT_USERNAME` | No | @username (no @) for the Connect-Telegram deep link; defaults to `coomander_bot`. Set to your dev bot's username in local dev. |
+| `TELEGRAM_WEBHOOK_URL` | Local Telegram dev | Public webhook URL used by `npm run telegram:webhook -- set` (your Cloudflare Tunnel host + `/api/coomander/webhook`). |
+| `CLOUDFLARE_TUNNEL_TOKEN` | Local Telegram dev | Token for the `cloudflared` sidecar; goes in the repo-root `.env`. See "Local Telegram dev". |
 
 Local: put these in `node/.env.local` (gitignored). Production: `npx wrangler secret put VAR_NAME`.
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -169,6 +169,15 @@ ADMIN_EMAILS=admin@example.com
 # setWebhook). Generate with `openssl rand -hex 24`. Set as a wrangler secret in
 # prod; the /api/coomander/webhook route 503s until it is set.
 # MADDIE_TELEGRAM_WEBHOOK_SECRET=
+# Bot @username (no @) used to build the "Connect Telegram" deep link
+# (t.me/<username>?start=<code>). Defaults to "coomander_bot" (prod). In LOCAL
+# dev set this to YOUR dev bot's username so the Connect flow points at the dev
+# bot, not prod's.
+# COOMANDER_BOT_USERNAME=coomander_bot
+# Full public URL Telegram should POST inbound updates to — used by
+# `npm run telegram:webhook -- set`. In dev this is your Cloudflare Tunnel
+# hostname + the webhook path. See README → "Local Telegram dev".
+# TELEGRAM_WEBHOOK_URL=https://dev-you.coomander.com/api/coomander/webhook
 # Anthropic model for Coomander pings + inbound classification (optional;
 # defaults to claude-sonnet-4-6).
 # COOMANDER_AGENT_MODEL=claude-sonnet-4-6

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,8 @@
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
     "docker:dev": "DOCKER_BUILDKIT=0 docker compose -f ../../docker-compose.yml --profile dev up --build",
+    "docker:dev:telegram": "DOCKER_BUILDKIT=0 docker compose -f ../../docker-compose.yml --profile dev --profile telegram up --build",
+    "telegram:webhook": "npx tsx scripts/telegram-webhook.ts",
     "email:dev": "email dev --dir emails"
   },
   "dependencies": {

--- a/apps/web/scripts/telegram-webhook.ts
+++ b/apps/web/scripts/telegram-webhook.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env npx tsx
+/**
+ * Register / inspect / clear the Telegram webhook for a Coomander bot (#215).
+ *
+ * Coomander's inbound is webhook-based (POST /api/coomander/webhook) and
+ * Telegram allows ONE webhook URL per bot. Prod's @coomander_bot already points
+ * at https://coomander.com/api/coomander/webhook, so LOCAL dev uses a SEPARATE
+ * dev bot (per developer) whose webhook points at that developer's Cloudflare
+ * Tunnel hostname. See README → "Local Telegram dev".
+ *
+ * Usage (from apps/web):
+ *   npm run telegram:webhook -- info        # getWebhookInfo (read-only, default)
+ *   npm run telegram:webhook -- set --yes   # setWebhook → $TELEGRAM_WEBHOOK_URL
+ *   npm run telegram:webhook -- delete      # deleteWebhook
+ *
+ * Reads from apps/web/.env.local:
+ *   MADDIE_TELEGRAM_BOT_TOKEN      the bot to operate on (your DEV bot in dev)
+ *   MADDIE_TELEGRAM_WEBHOOK_SECRET secret echoed in x-telegram-bot-api-secret-token
+ *   TELEGRAM_WEBHOOK_URL           full public URL, e.g.
+ *                                  https://dev-you.coomander.com/api/coomander/webhook
+ *
+ * Safety: `set` prints the resolved bot @username (getMe) and the target URL,
+ * then REQUIRES `--yes` — so you can't silently repoint the wrong bot (e.g.
+ * clobber prod's @coomander_bot if .env.local still holds the prod token).
+ */
+
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+const API = "https://api.telegram.org";
+
+type Cmd = "info" | "set" | "delete";
+
+interface TgResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+}
+
+async function tg<T>(token: string, method: string, body?: unknown): Promise<TgResponse<T>> {
+  const res = await fetch(`${API}/bot${token}/${method}`, {
+    method: body ? "POST" : "GET",
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return (await res.json().catch(() => ({ ok: false, description: `http ${res.status}` }))) as TgResponse<T>;
+}
+
+function fail(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const cmd = (args.find((a) => !a.startsWith("-")) ?? "info") as Cmd;
+  const yes = args.includes("--yes") || args.includes("-y");
+
+  if (!["info", "set", "delete"].includes(cmd)) {
+    fail(`unknown command "${cmd}". Use: info | set | delete`);
+  }
+
+  const token = process.env.MADDIE_TELEGRAM_BOT_TOKEN;
+  if (!token) fail("MADDIE_TELEGRAM_BOT_TOKEN not set in apps/web/.env.local");
+
+  // Always identify the target bot first — the guardrail against repointing the
+  // wrong bot (getMe is read-only).
+  const me = await tg<{ username?: string; id?: number }>(token, "getMe");
+  if (!me.ok) fail(`getMe failed: ${me.description ?? "unknown error"} (check MADDIE_TELEGRAM_BOT_TOKEN)`);
+  const botLabel = `@${me.result?.username ?? "?"} (id ${me.result?.id ?? "?"})`;
+  console.log(`Bot: ${botLabel}`);
+
+  if (cmd === "info") {
+    const info = await tg<Record<string, unknown>>(token, "getWebhookInfo");
+    if (!info.ok) fail(`getWebhookInfo failed: ${info.description}`);
+    const r = info.result ?? {};
+    console.log("Webhook info:");
+    console.log(`  url:                  ${r.url || "(none set)"}`);
+    console.log(`  pending_update_count: ${r.pending_update_count ?? 0}`);
+    console.log(`  has_custom_cert:      ${r.has_custom_certificate ?? false}`);
+    console.log(`  last_error_message:   ${r.last_error_message || "(none)"}`);
+    console.log(`  allowed_updates:      ${JSON.stringify(r.allowed_updates ?? "(default)")}`);
+    return;
+  }
+
+  if (cmd === "delete") {
+    const del = await tg(token, "deleteWebhook", { drop_pending_updates: true });
+    if (!del.ok) fail(`deleteWebhook failed: ${del.description}`);
+    console.log(`✓ Webhook deleted for ${botLabel}`);
+    return;
+  }
+
+  // cmd === "set"
+  const url = process.env.TELEGRAM_WEBHOOK_URL;
+  const secret = process.env.MADDIE_TELEGRAM_WEBHOOK_SECRET;
+  if (!url) fail("TELEGRAM_WEBHOOK_URL not set in apps/web/.env.local (e.g. https://dev-you.coomander.com/api/coomander/webhook)");
+  if (!secret) fail("MADDIE_TELEGRAM_WEBHOOK_SECRET not set in apps/web/.env.local");
+  if (!/^https:\/\//.test(url)) fail("TELEGRAM_WEBHOOK_URL must be https://");
+
+  console.log(`Will set webhook:\n  ${botLabel}\n  → ${url}`);
+  if (!yes) {
+    fail("refusing to set without confirmation. Re-run with --yes once you've verified the bot above is your DEV bot (not prod's @coomander_bot).");
+  }
+
+  const set = await tg(token, "setWebhook", {
+    url,
+    secret_token: secret,
+    allowed_updates: ["message"],
+    drop_pending_updates: true,
+  });
+  if (!set.ok) fail(`setWebhook failed: ${set.description}`);
+  console.log(`✓ Webhook set for ${botLabel} → ${url}`);
+}
+
+main().catch((e) => fail((e as Error).message));

--- a/changelogs/2026-06-23-dev-telegram-tunnel.md
+++ b/changelogs/2026-06-23-dev-telegram-tunnel.md
@@ -1,0 +1,44 @@
+---
+date: 2026-06-23
+scope: [node]
+category: feature
+files_changed:
+  - docker-compose.yml
+  - apps/web/scripts/telegram-webhook.ts
+  - apps/web/package.json
+  - .env.example
+  - apps/web/.env.example
+  - README.md
+requires_migration: false
+requires_env_vars: [CLOUDFLARE_TUNNEL_TOKEN, TELEGRAM_WEBHOOK_URL, COOMANDER_BOT_USERNAME]
+breaking: false
+---
+
+## Local Telegram dev: per-developer dev bot + Cloudflare Tunnel
+
+Lets any contributor run the dev server and use Telegram locally — the bot
+replying and the **Connect Telegram** link flow — against their own machine.
+
+Telegram allows **one webhook URL per bot**, and prod's `@coomander_bot` owns it,
+so each developer runs **their own dev bot** (BotFather) plus a **persistent
+Cloudflare named tunnel** that publishes a stable public hostname
+(`dev-<you>.coomander.com`) scoped to just the `/api/coomander/webhook` path.
+Everything is env-driven — **no app code changes**.
+
+- **`cloudflared` sidecar** in `docker-compose.yml`, opt-in via
+  `--profile telegram` (plain `docker compose up` is unaffected). Shares
+  `caddy-dev`'s netns so the tunnel reaches next dev at `localhost:3000`. Reads
+  `CLOUDFLARE_TUNNEL_TOKEN` (repo-root `.env`).
+- **`npm run telegram:webhook -- set|info|delete`**
+  (`apps/web/scripts/telegram-webhook.ts`) registers/inspects/clears the webhook
+  from `MADDIE_TELEGRAM_BOT_TOKEN` + `MADDIE_TELEGRAM_WEBHOOK_SECRET` +
+  `TELEGRAM_WEBHOOK_URL`. Prints the resolved bot `@username` (getMe) and
+  requires `--yes` to `set` — a guard against repointing prod's bot.
+- **`COOMANDER_BOT_USERNAME`** already drives the Connect deep link; set it to
+  your dev bot's username so the flow points at the dev bot in dev.
+- New convenience script `npm run docker:dev:telegram`; new env vars documented
+  in both `.env.example` files; README gains a "Local Telegram dev" section.
+
+Downstream projects with their own Telegram bot follow the same pattern: a dev
+bot + a named tunnel, with `COOMANDER_BOT_USERNAME`/`TELEGRAM_WEBHOOK_URL` per
+developer. Nothing here touches production.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,40 @@ services:
       NODE_ENV: development
     restart: unless-stopped
 
+  # ── Cloudflare Tunnel (opt-in: Telegram webhook in dev, #215) ────────────
+  # Telegram inbound is webhook-based and Telegram allows ONE webhook per bot,
+  # so each developer runs their OWN dev bot + their OWN named tunnel (prod's
+  # @coomander_bot owns the coomander.com webhook). This sidecar connects a
+  # Cloudflare *named* tunnel that publishes a stable public hostname
+  # (e.g. https://dev-<you>.coomander.com) so Telegram's servers can reach this
+  # machine's /api/coomander/webhook. Scope the tunnel's ingress to ONLY that
+  # path in the Cloudflare Zero Trust dashboard so the rest of the dev app stays
+  # private. See README → "Local Telegram dev".
+  #
+  # Opt-in: `docker compose --profile telegram up`. Plain `docker compose up`
+  # does NOT start it (no token needed for normal dev). Shares caddy-dev's netns
+  # so the tunnel's service target `http://localhost:3000` reaches next dev.
+  # cloudflared reads the token from TUNNEL_TOKEN natively; set
+  # CLOUDFLARE_TUNNEL_TOKEN in the repo-root .env (compose interpolation source).
+  cloudflared:
+    profiles: ["telegram"]
+    image: cloudflare/cloudflared:2026.6.1
+    container_name: coomander-cloudflared
+    network_mode: service:caddy-dev
+    depends_on:
+      - caddy-dev
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN:-}
+      # Bypass OrbStack's HTTP proxy for tunnel egress (mirrors caddy-dev).
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      NO_PROXY: "*"
+      http_proxy: ""
+      https_proxy: ""
+      no_proxy: "*"
+    command: tunnel --no-autoupdate run
+    restart: unless-stopped
+
 volumes:
   root_node_modules:
   web_node_modules:


### PR DESCRIPTION
Closes #215.

## What & why

Lets contributors (starting with Maddie) run the dev server and use Telegram locally — the bot replying + the **Connect Telegram** flow. Telegram allows **one webhook per bot** and prod's `@coomander_bot` owns it, so each developer runs **their own dev bot** + a **persistent Cloudflare named tunnel** (path-scoped to `/api/coomander/webhook`). Everything is env-driven — **no app code changes**.

Decision (with Mark): **Cloudflare Tunnel** + **per-developer dev bots**.

## Changes
- **`cloudflared` sidecar** (`docker-compose.yml`), opt-in via `--profile telegram`; shares `caddy-dev`'s netns so the tunnel reaches next dev at `localhost:3000`; reads `CLOUDFLARE_TUNNEL_TOKEN` (root `.env`). Plain `docker compose up` is unaffected. Image pinned `cloudflare/cloudflared:2026.6.1`.
- **`apps/web/scripts/telegram-webhook.ts`** + `npm run telegram:webhook -- set|info|delete`: registers/inspects/clears the webhook from `MADDIE_TELEGRAM_BOT_TOKEN` + `MADDIE_TELEGRAM_WEBHOOK_SECRET` + `TELEGRAM_WEBHOOK_URL`. Prints the resolved bot `@username` (getMe) and **requires `--yes`** to `set` (guard against repointing prod's bot).
- **`npm run docker:dev:telegram`** convenience script.
- **Env docs**: `CLOUDFLARE_TUNNEL_TOKEN` (root `.env.example`); `COOMANDER_BOT_USERNAME` + `TELEGRAM_WEBHOOK_URL` (`apps/web/.env.example`); README env table.
- **README** "Local Telegram dev" section (BotFather → named tunnel w/ path-scoped ingress → env → `--profile telegram up` → run script → connect in-app).
- Changelog entry.

## Verification done locally
- `docker compose config` → cloudflared absent; `--profile telegram config` → present + parses; image tag verified on Docker Hub.
- `npm run telegram:webhook -- info` works (read-only); `set` without `--yes` aborts before any mutation; **prod `@coomander_bot` webhook confirmed untouched** (still → coomander.com, 0 pending, no errors).
- `tsc --noEmit` clean.

## Not covered here (needs human setup → QA issue)
Full live E2E — creating a real dev bot in @BotFather + a Cloudflare named tunnel, then `set` + connect + send a message — requires the per-developer BotFather/Cloudflare steps. Tracked in the QA issue.

No unit tests: this is dev infra + a thin Telegram-API wrapper script (manually verified). No prod impact.

QA: #217