### PR TITLE
Release v0.3.0 — Telegram inbound multi-provider + dev Telegram tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,15 @@ DEV_PORT=3005
 # (verification, password reset) link back to the externally-reachable
 # domain, not localhost.
 APP_URL=https://coomander.gate-cardassian.ts.net
+
+# ── Local Telegram dev (opt-in, #215) ──────────────────────────────────
+# Only needed if you want inbound Telegram (the bot replying / the Connect
+# flow) to work against YOUR local dev server. Telegram allows one webhook per
+# bot, so each developer runs their OWN dev bot + their OWN Cloudflare named
+# tunnel. This token is for the `cloudflared` sidecar (started only with
+# `docker compose --profile telegram up`). Create a named tunnel in the
+# Cloudflare Zero Trust dashboard, scope its public hostname's ingress to the
+# /api/coomander/webhook path → http://localhost:3000, and paste its token here.
+# The dev bot token + webhook URL go in apps/web/.env.local. Full walkthrough:
+# README → "Local Telegram dev". Leave blank for normal (non-Telegram) dev.
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/README.md
+++ b/README.md
@@ -88,6 +88,51 @@ OAuth providers (Google, GitHub, Microsoft) need both URLs allow-listed:
 
 Set up via `/configure-sso` — it knows about both.
 
+## Local Telegram dev (per-developer bot + Cloudflare Tunnel)
+
+Coomander's Telegram inbound is **webhook-based** (`POST /api/coomander/webhook`), and **Telegram allows exactly one webhook URL per bot.** Production's `@coomander_bot` already owns it (→ `https://coomander.com/api/coomander/webhook`). So to use Telegram against *your* local dev server — the bot replying, and the **Connect Telegram** link flow — you run **your own dev bot** plus a **persistent Cloudflare Tunnel** to your machine.
+
+> Optional. Skip this entirely for normal dev — `docker compose up` works without it; only outbound features that *send* Telegram need a token, and inbound needs this tunnel.
+
+### One-time setup
+
+1. **Create a dev bot.** In Telegram, message [@BotFather](https://t.me/BotFather) → `/newbot` → name it (e.g. `Coomander Dev (you)`), username e.g. `coomander_dev_you_bot`. Save the **bot token** and the **@username**.
+
+2. **Create a Cloudflare named tunnel** (free; uses the existing `coomander.com` zone). In the [Zero Trust dashboard](https://one.dash.cloudflare.com) → **Networks → Tunnels → Create a tunnel** → *Cloudflared*:
+   - Name it `coomander-dev-<you>`; copy the **tunnel token**.
+   - Add a **Public Hostname**: subdomain `dev-<you>`, domain `coomander.com`, **Path** `api/coomander/webhook`, Service `HTTP` → `localhost:3000`. (Path-scoping keeps the rest of your dev server private; the catch-all stays a 404.)
+
+3. **Set env vars.**
+   - Repo-root `.env` (compose interpolation): `CLOUDFLARE_TUNNEL_TOKEN=<tunnel token>`
+   - `apps/web/.env.local`:
+     ```bash
+     MADDIE_TELEGRAM_BOT_TOKEN=<your dev bot token>
+     MADDIE_TELEGRAM_WEBHOOK_SECRET=$(openssl rand -hex 24)
+     COOMANDER_BOT_USERNAME=coomander_dev_you_bot         # so the Connect link points at YOUR dev bot
+     TELEGRAM_WEBHOOK_URL=https://dev-you.coomander.com/api/coomander/webhook
+     ```
+
+### Each session
+
+```bash
+# from apps/web — starts the normal stack PLUS the cloudflared sidecar
+npm run docker:dev:telegram          # = docker compose --profile dev --profile telegram up --build
+
+# register your dev bot's webhook at your tunnel (one-time per bot, or after changing the URL)
+npm run telegram:webhook -- set --yes
+npm run telegram:webhook -- info     # verify: url + 0 pending + no last_error
+```
+
+The `set` command prints the resolved bot `@username` first and **requires `--yes`** — a guard so you can't accidentally repoint prod's `@coomander_bot` (verify the username is your dev bot before confirming).
+
+Then open the app (localhost:3005 or the tailnet URL), go to the home/onboarding **Connect Telegram** card → tap the deep link (or send the code) to **your dev bot** → it links your local user. Now pings and replies flow through your machine.
+
+### Notes
+
+- **One webhook per bot** is why each developer needs their own bot — two people can't point the same bot at two tunnels.
+- `npm run telegram:webhook -- delete` clears your dev bot's webhook (e.g. before stepping away).
+- Never put `COOMANDER_TELEGRAM_DISABLED` in `.env.local` — it bakes into the prod bundle.
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -105,6 +150,11 @@ Set up via `/configure-sso` — it knows about both.
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | If using GitHub SSO | OAuth credentials. |
 | `ANTHROPIC_API_KEY` | If using AI chat | Claude API for the chat surface. |
 | `ELEVENLABS_API_KEY` | If using voice | ElevenLabs TTS (optional — chat falls back to text). |
+| `MADDIE_TELEGRAM_BOT_TOKEN` | If using Telegram | Bot token from @BotFather. Prod = `@coomander_bot`; local dev = your own dev bot (see "Local Telegram dev"). |
+| `MADDIE_TELEGRAM_WEBHOOK_SECRET` | If using Telegram inbound | Secret echoed on the inbound webhook; `openssl rand -hex 24`. |
+| `COOMANDER_BOT_USERNAME` | No | @username (no @) for the Connect-Telegram deep link; defaults to `coomander_bot`. Set to your dev bot's username in local dev. |
+| `TELEGRAM_WEBHOOK_URL` | Local Telegram dev | Public webhook URL used by `npm run telegram:webhook -- set` (your Cloudflare Tunnel host + `/api/coomander/webhook`). |
+| `CLOUDFLARE_TUNNEL_TOKEN` | Local Telegram dev | Token for the `cloudflared` sidecar; goes in the repo-root `.env`. See "Local Telegram dev". |
 
 Local: put these in `node/.env.local` (gitignored). Production: `npx wrangler secret put VAR_NAME`.
 

--- a/apps/agents/package.json
+++ b/apps/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coomander/agents",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Coomander sidecar agent Worker — Coomander as a per-user stateful agent on the Cloudflare Agents SDK",
   "scripts": {

--- a/apps/agents/scripts/dev.sh
+++ b/apps/agents/scripts/dev.sh
@@ -10,6 +10,9 @@
 set -e
 
 ARGS="--persist-to .wrangler/state"
+if [ "${COOMANDER_AGENTS_LOCAL_ONLY:-}" = "true" ]; then
+  ARGS="--local $ARGS"
+fi
 # Default port 8788 (what Caddy's /agents/* route targets) unless the caller
 # passes their own --port.
 case " $* " in

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -169,6 +169,15 @@ ADMIN_EMAILS=admin@example.com
 # setWebhook). Generate with `openssl rand -hex 24`. Set as a wrangler secret in
 # prod; the /api/coomander/webhook route 503s until it is set.
 # MADDIE_TELEGRAM_WEBHOOK_SECRET=
+# Bot @username (no @) used to build the "Connect Telegram" deep link
+# (t.me/<username>?start=<code>). Defaults to "coomander_bot" (prod). In LOCAL
+# dev set this to YOUR dev bot's username so the Connect flow points at the dev
+# bot, not prod's.
+# COOMANDER_BOT_USERNAME=coomander_bot
+# Full public URL Telegram should POST inbound updates to — used by
+# `npm run telegram:webhook -- set`. In dev this is your Cloudflare Tunnel
+# hostname + the webhook path. See README → "Local Telegram dev".
+# TELEGRAM_WEBHOOK_URL=https://dev-you.coomander.com/api/coomander/webhook
 # Anthropic model for Coomander pings + inbound classification (optional;
 # defaults to claude-sonnet-4-6).
 # COOMANDER_AGENT_MODEL=claude-sonnet-4-6

--- a/apps/web/app/app/chat/page.tsx
+++ b/apps/web/app/app/chat/page.tsx
@@ -140,14 +140,19 @@ function CoomanderChat() {
         wsResolveRef.current = null;
       },
       onError: (message) => {
+        const turnWasActive = wsTurnRef.current || sendingRef.current;
         wsTurnRef.current = false;
         setStreamText(null);
         setSending(false);
         sendingRef.current = false;
-        setMessages((m) => [
-          ...m,
-          { id: `err-${Date.now()}`, role: "assistant", content: message },
-        ]);
+        // Socket reconnects happen in the background. Only render an error as
+        // part of the conversation when a user turn was actually in flight.
+        if (turnWasActive) {
+          setMessages((m) => [
+            ...m,
+            { id: `err-${Date.now()}`, role: "assistant", content: message },
+          ]);
+        }
         wsResolveRef.current?.();
         wsResolveRef.current = null;
       },

--- a/apps/web/content/docs/dev/ai-models.mdx
+++ b/apps/web/content/docs/dev/ai-models.mdx
@@ -16,6 +16,11 @@ Workers AI models — run through one `streamText` path on the agents Worker.
 > (`apps/agents`) over a WebSocket. `GET /api/coomander/chat` only hydrates the
 > thread on mount/refresh; there is no `POST` send handler.
 
+Telegram inbound uses `lib/coomander/inbound.ts`. Execution statements are
+classified into domain tools. Common read-only planning questions such as
+"What do I need to get done today?" bypass the write-action classifier and
+render a deterministic, ramp-aware answer from `TodayModel`.
+
 ## The catalog (`@coomander/core`)
 
 The single source of truth for which models exist lives in
@@ -125,7 +130,11 @@ the top-level and `[env.production]` wrangler envs — the top-level is what
 
 - **On Cloudflare Workers (prod)** — the binding works directly. No key; billed
   via the CF account.
-- **Local / Docker dev** — Workers AI inference can't run in local miniflare, so
+- **Local / Docker dev** — Docker defaults to explicit Wrangler `--local` mode,
+  which keeps Claude chat available with only `ANTHROPIC_API_KEY`; the Workers
+  AI binding is unavailable and selected open models fall back to Claude. Set
+  `COOMANDER_AGENTS_LOCAL_ONLY=false` when intentionally testing Workers AI.
+  Workers AI inference can't run in local miniflare, so
   `wrangler dev` proxies the `AI` binding to **remote** Cloudflare. It does this by
   deploying a temporary **preview Worker**, so the credential needs **Workers
   Scripts** access — **not just Workers AI**. A Workers-AI-only token can run AI

--- a/apps/web/lib/coomander/coomanderChat.ts
+++ b/apps/web/lib/coomander/coomanderChat.ts
@@ -18,7 +18,8 @@ import { getCoomanderSettings, userToday } from "./settings";
 import { coomanderSystem } from "./agentPrompts";
 import { getTodayModel } from "./todayModel";
 import { renderContext, daysSinceStart } from "./agent";
-import { tools, resolveToolUse, executeAction, loadContext } from "./inbound";
+import { TOOLS, resolveToolUse, executeAction, loadContext } from "./inbound";
+import { CONTENT_STATES } from "./contentStates";
 
 const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
 
@@ -86,10 +87,111 @@ export async function chatSystemPrompt(userId: string): Promise<string> {
 
 /**
  * The Coomander domain tool schemas (Anthropic.Tool[]), exported for the agents
- * Worker contract route. Same vocabulary the classifier + in-app chat use.
+ * Worker contract route (served as `{name, description, input_schema}` JSON and
+ * re-wrapped via `jsonSchema()` on the Worker). Same vocabulary as the Telegram
+ * inbound classifier, which uses the Vercel-AI-SDK/zod representation in
+ * `inbound.ts::inboundTools()` (#218 moved the classifier off the Anthropic SDK).
+ *
+ * IMPORTANT: these definitions MUST stay in sync with `inboundTools()` — same
+ * tool names, property names, enums, and required/optional shape — so the agent
+ * chat and the Telegram classifier validate identically through
+ * `resolveToolUse`/`executeAction`. (Kept as two representations on purpose: the
+ * agent path consumes JSON Schema, the classifier consumes zod; unifying them
+ * behind one source is a sensible follow-up.)
  */
 export function chatTools(): Anthropic.Tool[] {
-  return tools();
+  return [
+    {
+      name: TOOLS.LOG_DROP,
+      description:
+        "Record an act of execution against one of the creator's beats: a reel shipped, a live stream done, wall content captured. 'kind' is 'shipped' for a posted/published piece, 'captured' for wall content shot but not yet posted, 'completed' for a non-content task, 'purchased' is not used here (use log_purchase). Set platform when known.",
+      input_schema: {
+        type: "object",
+        properties: {
+          beat_id: { type: "string", description: "id of the matched beat (from the list provided)." },
+          kind: { type: "string", enum: ["shipped", "captured", "completed"], description: "shipped=posted; captured=shot for the wall buffer; completed=other task." },
+          count: { type: "integer", minimum: 1, description: "How many of THIS beat were shipped/captured in this message (e.g. 'posted 2 reels' -> 2). Defaults to 1. Use one log_drop with count=N for N of the same beat; use separate log_drop calls for different beats." },
+          platform: { type: "string", enum: ["ig", "tiktok", "fb", "snap", "of"], description: "Platform, if stated or obvious." },
+          notes: { type: "string", description: "Optional free text." },
+        },
+        required: ["beat_id", "kind"],
+      },
+    },
+    {
+      name: TOOLS.ADVANCE,
+      description:
+        "Move a content item to a new lifecycle state (e.g. 'the editor finished the gym reel' -> edited). You may advance one step forward or move backward with a reason. States: drafted, shot, approved, uploaded_to_edit, edited, scheduled, shipped.",
+      input_schema: {
+        type: "object",
+        properties: {
+          content_id: { type: "string", description: "id of the content item (from the list provided)." },
+          new_state: { type: "string", enum: CONTENT_STATES as unknown as string[], description: "The target state." },
+          notes: { type: "string", description: "Reason (required when moving backward)." },
+        },
+        required: ["content_id", "new_state"],
+      },
+    },
+    {
+      name: TOOLS.LOG_PURCHASE,
+      description: "Mark a procurement item as received/purchased (e.g. 'the Halloween costume arrived').",
+      input_schema: {
+        type: "object",
+        properties: {
+          procurement_item_id: { type: "string", description: "id of the procurement item (from the list provided)." },
+          actual_cost: { type: "number", description: "Optional actual cost in dollars." },
+          notes: { type: "string" },
+        },
+        required: ["procurement_item_id"],
+      },
+    },
+    {
+      name: TOOLS.ADD_PROCUREMENT,
+      description: "Add a new thing to acquire (e.g. 'I need new ring lights by next Friday'). category: shoot_prep (costumes, props, lights, locations) or business_admin (invoices, gear, tax).",
+      input_schema: {
+        type: "object",
+        properties: {
+          category: { type: "string", enum: ["shoot_prep", "business_admin"] },
+          label: { type: "string", description: "Short label for the item." },
+          needed_by: { type: "string", description: "Optional deadline as YYYY-MM-DD (resolve relative dates against today)." },
+          notes: { type: "string" },
+        },
+        required: ["category", "label"],
+      },
+    },
+    {
+      name: TOOLS.MARK_BLOCKER,
+      description: "The creator can't execute today (e.g. 'can't shoot today, sick'). Sets the day to a bad day so Coomander softens and suppresses midday nags.",
+      input_schema: {
+        type: "object",
+        properties: {
+          beat_id: { type: "string", description: "Optional beat this blocks." },
+          reason: { type: "string", description: "Short reason." },
+        },
+        required: ["reason"],
+      },
+    },
+    {
+      name: TOOLS.ADJUST_BEAT,
+      description: "Change a beat's target (e.g. 'cut me down to 3 reels a week this month').",
+      input_schema: {
+        type: "object",
+        properties: {
+          beat_id: { type: "string", description: "id of the beat to adjust." },
+          target_count: { type: "number", description: "New target count." },
+        },
+        required: ["beat_id"],
+      },
+    },
+    {
+      name: TOOLS.CLARIFY,
+      description: "Ask a short clarifying question. Use when the message does not clearly match one beat/content/procurement item, or is not about logging at all. Never guess.",
+      input_schema: {
+        type: "object",
+        properties: { reply: { type: "string", description: "A short friendly question. No em-dashes." } },
+        required: ["reply"],
+      },
+    },
+  ];
 }
 
 /**

--- a/apps/web/lib/coomander/inbound-model.ts
+++ b/apps/web/lib/coomander/inbound-model.ts
@@ -1,0 +1,98 @@
+/**
+ * Model resolution for the Telegram inbound classifier (#218).
+ *
+ * The web worker's NON-streaming counterpart to the agents worker's
+ * `apps/agents/src/chat-model.ts::resolveAgentModel`. It maps the
+ * admin/per-user-chosen catalog model (via `resolveActiveModelId`) to a Vercel
+ * AI SDK `LanguageModel`, dispatching on the entry's provider:
+ *   - anthropic  → createAnthropic (env ANTHROPIC_API_KEY)
+ *   - cloudflare → createWorkersAI({ binding: env.AI })
+ *
+ * The classifier REQUIRES forced tool-calling, so any chosen model without tool
+ * support (or an unknown id) falls back to the Anthropic default. In `next dev`
+ * there is no `[ai]` binding, so a Workers-AI choice also falls back to Anthropic
+ * (real Workers-AI dispatch happens only in the deployed worker). Every fallback
+ * is logged and the function never throws — Telegram parsing must not break.
+ *
+ * NOTE: the agents worker wraps the Workers-AI binding in an SSE-dedupe Proxy;
+ * that is STREAMING-only. The classifier uses non-streaming `generateText`, so
+ * the shim is intentionally omitted here.
+ */
+
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createWorkersAI } from "workers-ai-provider";
+import type { LanguageModel } from "ai";
+import { getModel } from "@/lib/model-catalog";
+import { resolveActiveModelId } from "@/lib/active-model";
+import { log } from "@/lib/logger";
+
+/** env-tier default — the pre-#218 inbound model + the universal fallback. */
+export const ANTHROPIC_FALLBACK_ID =
+  process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
+
+export interface InboundModel {
+  model: LanguageModel;
+  resolvedId: string;
+  provider: string;
+  /** True when we fell back to the Anthropic default instead of the chosen model. */
+  fellBack: boolean;
+}
+
+/**
+ * The Workers AI binding for THIS (web) worker, or null in `next dev` (no
+ * binding) / when the OpenNext context can't be resolved. Lazy `require` mirrors
+ * lib/db.ts — `getCloudflareContext` only resolves inside the Workers runtime.
+ */
+function workersAiBinding(): unknown | null {
+  try {
+    const { getCloudflareContext } = require("@opennextjs/cloudflare");
+    return getCloudflareContext()?.env?.AI ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function anthropicModel(id: string, fellBack: boolean): InboundModel {
+  return {
+    model: createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })(id),
+    resolvedId: id,
+    provider: "anthropic",
+    fellBack,
+  };
+}
+
+export async function resolveInboundModel(userId: string): Promise<InboundModel> {
+  const chosenId = await resolveActiveModelId({ userId }).catch(() => ANTHROPIC_FALLBACK_ID);
+  const entry = getModel(chosenId);
+
+  // The classifier REQUIRES forced tool-calling → models without tool support
+  // (or unknown ids) fall back to the Anthropic default.
+  if (!entry || !entry.supportsTools) {
+    if (entry && !entry.supportsTools) {
+      log.info("[inbound-model] chosen model has no tool support; using Anthropic default", { chosenId });
+    }
+    return anthropicModel(ANTHROPIC_FALLBACK_ID, chosenId !== ANTHROPIC_FALLBACK_ID);
+  }
+
+  switch (entry.provider) {
+    case "anthropic":
+      return anthropicModel(entry.id, false);
+    case "cloudflare": {
+      const ai = workersAiBinding();
+      if (!ai) {
+        // dev `next dev` has no [ai] binding → graceful fallback.
+        log.warn("[inbound-model] Workers AI chosen but env.AI binding missing; using Anthropic default", { chosenId: entry.id });
+        return anthropicModel(ANTHROPIC_FALLBACK_ID, true);
+      }
+      return {
+        model: createWorkersAI({ binding: ai as never })(entry.id),
+        resolvedId: entry.id,
+        provider: "cloudflare",
+        fellBack: false,
+      };
+    }
+    default:
+      log.warn("[inbound-model] provider not wired for inbound; using Anthropic default", { provider: entry.provider });
+      return anthropicModel(ANTHROPIC_FALLBACK_ID, true);
+  }
+}

--- a/apps/web/lib/coomander/inbound.ts
+++ b/apps/web/lib/coomander/inbound.ts
@@ -24,6 +24,9 @@ import { listProcurement, createProcurement, updateProcurement, type Procurement
 import { setDayQuality } from "./scheduling";
 import { checkWallProhibitions } from "./wallProhibitions";
 import { userToday, type PersonaMode } from "./settings";
+import { getTodayModel, type TodayModel } from "./todayModel";
+import { daysSinceStart } from "./agent";
+import { expectedToday } from "./ramp";
 import type { ContentStateValue, CadenceBeat, ContentState, ProcurementItem } from "@/lib/schema";
 
 const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
@@ -40,6 +43,49 @@ export const TOOLS = {
 
 const FALLBACK_REPLY =
   "I could not tell exactly what to log there. Try naming the beat or content, like \"posted the gym reel\" or \"halloween costume arrived\".";
+
+export function isTodayPlanQuestion(text: string): boolean {
+  const normalized = text.trim().toLowerCase().replace(/[?!.,]+$/g, "");
+  return [
+    /\bwhat (?:do|should) i (?:need to )?(?:do|get done|work on|focus on)(?: today)?\b/,
+    /\bwhat(?:'s| is) (?:on )?(?:my|the) (?:plan|plate|table|list)(?: today)?\b/,
+    /\bwhat(?:'s| is) (?:the )?plan for today\b/,
+  ].some((pattern) => pattern.test(normalized));
+}
+
+export function todayPlanReply(model: TodayModel, daysIn: number): string {
+  const tasks: string[] = [];
+  const cushionUnit = model.content_cushion_days === 1 ? "day" : "days";
+
+  for (const pillar of model.pillars) {
+    for (const item of pillar.beats) {
+      const expected = expectedToday(item.beat, daysIn);
+      const remaining = Math.max(0, expected - item.actual_today);
+      if (remaining > 0) {
+        tasks.push(`${item.beat.name}: ${remaining} remaining`);
+      }
+
+      const buffer = item.buffer_status;
+      if (buffer && buffer.current_days < buffer.goal_days) {
+        tasks.push(`${item.beat.name}: build the buffer (${buffer.current_days}/${buffer.goal_days} days)`);
+      }
+    }
+  }
+
+  const urgent = [
+    ...model.procurement_urgent.shoot_prep,
+    ...model.procurement_urgent.business_admin,
+  ];
+  for (const item of urgent) {
+    tasks.push(`Get ${item.label}${item.needed_by ? ` by ${item.needed_by}` : ""}`);
+  }
+
+  if (!tasks.length) {
+    return `You're clear on today's tracked cadence. Your content cushion is ${model.content_cushion_days} ${cushionUnit}.`;
+  }
+
+  return `Today: ${tasks.join("; ")}. Content cushion: ${model.content_cushion_days} ${cushionUnit}.`;
+}
 
 export interface ClassifiedTool {
   toolName: string;
@@ -358,6 +404,16 @@ export async function loadContext(userId: string): Promise<InboundContext> {
  * tool call (for persistence), and whether a row was written.
  */
 export async function handleInbound(userId: string, text: string, personaMode: PersonaMode = "light_companion"): Promise<InboundResult> {
+  if (isTodayPlanQuestion(text)) {
+    const date = await userToday(userId);
+    const model = await getTodayModel(userId, date);
+    return {
+      reply: todayPlanReply(model, await daysSinceStart(userId, date)),
+      toolCall: [{ toolName: "answer_today", input: {} }],
+      acted: false,
+    };
+  }
+
   const ctx = await loadContext(userId);
   const classified = await classifyMessage(userId, text, ctx, personaMode);
   if (!classified.length) return { reply: FALLBACK_REPLY, toolCall: null, acted: false };

--- a/apps/web/lib/coomander/inbound.ts
+++ b/apps/web/lib/coomander/inbound.ts
@@ -13,7 +13,9 @@
  * validated match; anything ambiguous becomes need_clarification.
  */
 
-import Anthropic from "@anthropic-ai/sdk";
+import { generateText, tool, type ModelMessage } from "ai";
+import { z } from "zod";
+import { resolveInboundModel } from "./inbound-model";
 import { logCoomanderUsage } from "./usage";
 import { listMessages } from "./coomanderMessages";
 import { listBeats } from "./beats";
@@ -28,8 +30,6 @@ import { getTodayModel, type TodayModel } from "./todayModel";
 import { daysSinceStart } from "./agent";
 import { expectedToday } from "./ramp";
 import type { ContentStateValue, CadenceBeat, ContentState, ProcurementItem } from "@/lib/schema";
-
-const MODEL = process.env.COOMANDER_AGENT_MODEL || process.env.CHAT_MODEL || "claude-sonnet-4-6";
 
 export const TOOLS = {
   LOG_DROP: "log_drop",
@@ -106,101 +106,73 @@ export interface InboundContext {
   procurement: ProcurementItem[];
 }
 
-// ── Anthropic tool definitions ────────────────────────────────────────────────
+// ── Tool definitions (Vercel AI SDK + zod) ─────────────────────────────────────
+// One tool per TOOLS.* name, keyed identically so resolveToolUse/executeAction
+// are untouched. No `execute` — the model's tool calls are returned for our own
+// validation (resolveToolUse) rather than auto-executed. Tool descriptions are
+// verbatim from the prior Anthropic schema; property hints preserved via
+// `.describe()`. Exported so a test can assert the tool shapes.
 
-export function tools(): Anthropic.Tool[] {
-  return [
-    {
-      name: TOOLS.LOG_DROP,
+export function inboundTools() {
+  return {
+    [TOOLS.LOG_DROP]: tool({
       description:
         "Record an act of execution against one of the creator's beats: a reel shipped, a live stream done, wall content captured. 'kind' is 'shipped' for a posted/published piece, 'captured' for wall content shot but not yet posted, 'completed' for a non-content task, 'purchased' is not used here (use log_purchase). Set platform when known.",
-      input_schema: {
-        type: "object",
-        properties: {
-          beat_id: { type: "string", description: "id of the matched beat (from the list provided)." },
-          kind: { type: "string", enum: ["shipped", "captured", "completed"], description: "shipped=posted; captured=shot for the wall buffer; completed=other task." },
-          count: { type: "integer", minimum: 1, description: "How many of THIS beat were shipped/captured in this message (e.g. 'posted 2 reels' -> 2). Defaults to 1. Use one log_drop with count=N for N of the same beat; use separate log_drop calls for different beats." },
-          platform: { type: "string", enum: ["ig", "tiktok", "fb", "snap", "of"], description: "Platform, if stated or obvious." },
-          notes: { type: "string", description: "Optional free text." },
-        },
-        required: ["beat_id", "kind"],
-      },
-    },
-    {
-      name: TOOLS.ADVANCE,
+      inputSchema: z.object({
+        beat_id: z.string().describe("id of the matched beat (from the list provided)."),
+        kind: z.enum(["shipped", "captured", "completed"]).describe("shipped=posted; captured=shot for the wall buffer; completed=other task."),
+        count: z.number().int().min(1).optional().describe("How many of THIS beat were shipped/captured in this message (e.g. 'posted 2 reels' -> 2). Defaults to 1. Use one log_drop with count=N for N of the same beat; use separate log_drop calls for different beats."),
+        platform: z.enum(["ig", "tiktok", "fb", "snap", "of"]).optional().describe("Platform, if stated or obvious."),
+        notes: z.string().optional().describe("Optional free text."),
+      }),
+    }),
+    [TOOLS.ADVANCE]: tool({
       description:
         "Move a content item to a new lifecycle state (e.g. 'the editor finished the gym reel' -> edited). You may advance one step forward or move backward with a reason. States: drafted, shot, approved, uploaded_to_edit, edited, scheduled, shipped.",
-      input_schema: {
-        type: "object",
-        properties: {
-          content_id: { type: "string", description: "id of the content item (from the list provided)." },
-          new_state: { type: "string", enum: CONTENT_STATES as unknown as string[], description: "The target state." },
-          notes: { type: "string", description: "Reason (required when moving backward)." },
-        },
-        required: ["content_id", "new_state"],
-      },
-    },
-    {
-      name: TOOLS.LOG_PURCHASE,
+      inputSchema: z.object({
+        content_id: z.string().describe("id of the content item (from the list provided)."),
+        new_state: z.enum(CONTENT_STATES as unknown as [string, ...string[]]).describe("The target state."),
+        notes: z.string().optional().describe("Reason (required when moving backward)."),
+      }),
+    }),
+    [TOOLS.LOG_PURCHASE]: tool({
       description: "Mark a procurement item as received/purchased (e.g. 'the Halloween costume arrived').",
-      input_schema: {
-        type: "object",
-        properties: {
-          procurement_item_id: { type: "string", description: "id of the procurement item (from the list provided)." },
-          actual_cost: { type: "number", description: "Optional actual cost in dollars." },
-          notes: { type: "string" },
-        },
-        required: ["procurement_item_id"],
-      },
-    },
-    {
-      name: TOOLS.ADD_PROCUREMENT,
+      inputSchema: z.object({
+        procurement_item_id: z.string().describe("id of the procurement item (from the list provided)."),
+        actual_cost: z.number().optional().describe("Optional actual cost in dollars."),
+        notes: z.string().optional(),
+      }),
+    }),
+    [TOOLS.ADD_PROCUREMENT]: tool({
       description: "Add a new thing to acquire (e.g. 'I need new ring lights by next Friday'). category: shoot_prep (costumes, props, lights, locations) or business_admin (invoices, gear, tax).",
-      input_schema: {
-        type: "object",
-        properties: {
-          category: { type: "string", enum: ["shoot_prep", "business_admin"] },
-          label: { type: "string", description: "Short label for the item." },
-          needed_by: { type: "string", description: "Optional deadline as YYYY-MM-DD (resolve relative dates against today)." },
-          notes: { type: "string" },
-        },
-        required: ["category", "label"],
-      },
-    },
-    {
-      name: TOOLS.MARK_BLOCKER,
+      inputSchema: z.object({
+        category: z.enum(["shoot_prep", "business_admin"]),
+        label: z.string().describe("Short label for the item."),
+        needed_by: z.string().optional().describe("Optional deadline as YYYY-MM-DD (resolve relative dates against today)."),
+        notes: z.string().optional(),
+      }),
+    }),
+    [TOOLS.MARK_BLOCKER]: tool({
       description: "The creator can't execute today (e.g. 'can't shoot today, sick'). Sets the day to a bad day so Coomander softens and suppresses midday nags.",
-      input_schema: {
-        type: "object",
-        properties: {
-          beat_id: { type: "string", description: "Optional beat this blocks." },
-          reason: { type: "string", description: "Short reason." },
-        },
-        required: ["reason"],
-      },
-    },
-    {
-      name: TOOLS.ADJUST_BEAT,
+      inputSchema: z.object({
+        beat_id: z.string().optional().describe("Optional beat this blocks."),
+        reason: z.string().describe("Short reason."),
+      }),
+    }),
+    [TOOLS.ADJUST_BEAT]: tool({
       description: "Change a beat's target (e.g. 'cut me down to 3 reels a week this month').",
-      input_schema: {
-        type: "object",
-        properties: {
-          beat_id: { type: "string", description: "id of the beat to adjust." },
-          target_count: { type: "number", description: "New target count." },
-        },
-        required: ["beat_id"],
-      },
-    },
-    {
-      name: TOOLS.CLARIFY,
+      inputSchema: z.object({
+        beat_id: z.string().describe("id of the beat to adjust."),
+        target_count: z.number().optional().describe("New target count."),
+      }),
+    }),
+    [TOOLS.CLARIFY]: tool({
       description: "Ask a short clarifying question. Use when the message does not clearly match one beat/content/procurement item, or is not about logging at all. Never guess.",
-      input_schema: {
-        type: "object",
-        properties: { reply: { type: "string", description: "A short friendly question. No em-dashes." } },
-        required: ["reply"],
-      },
-    },
-  ];
+      inputSchema: z.object({
+        reply: z.string().describe("A short friendly question. No em-dashes."),
+      }),
+    }),
+  };
 }
 
 function contextString(ctx: InboundContext): string {
@@ -355,10 +327,9 @@ export async function executeAction(userId: string, action: ResolvedAction, ctx:
   }
 }
 
-// ── Anthropic classification ───────────────────────────────────────────────────
+// ── Multi-provider classification (#218) ────────────────────────────────────────
 
 async function classifyMessage(userId: string, text: string, ctx: InboundContext, personaMode: PersonaMode): Promise<ClassifiedTool[]> {
-  const client = new Anthropic();
   // Inject the recent thread (oldest-first) so a clarification answer resolves
   // against the message that prompted it — e.g. "normal reels" right after
   // "posted 2 gym reels" must log a drop, not ask again. The current inbound
@@ -371,18 +342,20 @@ async function classifyMessage(userId: string, text: string, ctx: InboundContext
         .map((m) => `${m.direction === "inbound" ? "creator" : "coomander"}: ${m.text}`)
         .join("\n")}\n\nIf the newest message answers a clarification you just asked, combine it with that earlier context and take the action — do not ask the same question again.`
     : "";
-  const msg = await client.messages.create({
-    model: MODEL,
-    max_tokens: 300,
-    system: [{ type: "text", text: systemPrompt(ctx, personaMode, today) + history, cache_control: { type: "ephemeral" } }],
-    tool_choice: { type: "any" },
-    tools: tools(),
-    messages: [{ role: "user", content: text }],
+  // Resolve the admin/per-user-chosen model (Anthropic or Workers AI) via the
+  // multi-provider engine; falls back to the Anthropic default when the chosen
+  // model lacks tool support or its binding is unavailable (see inbound-model).
+  const { model, resolvedId } = await resolveInboundModel(userId);
+  const result = await generateText({
+    model,
+    maxOutputTokens: 300,
+    system: systemPrompt(ctx, personaMode, today) + history,
+    tools: inboundTools(),
+    toolChoice: "required",
+    messages: [{ role: "user", content: text }] as ModelMessage[],
   });
-  await logCoomanderUsage(userId, "inbound", MODEL, msg.usage?.input_tokens, msg.usage?.output_tokens);
-  return msg.content
-    .filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use")
-    .map((b) => ({ toolName: b.name, input: (b.input ?? {}) as Record<string, unknown> }));
+  await logCoomanderUsage(userId, "inbound", resolvedId, result.usage?.inputTokens, result.usage?.outputTokens).catch(() => {});
+  return result.toolCalls.map((tc) => ({ toolName: tc.toolName, input: (tc.input ?? {}) as Record<string, unknown> }));
 }
 
 /** Load the classifier context (active beats, unshipped content, open procurement). */

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,8 @@
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
     "docker:dev": "DOCKER_BUILDKIT=0 docker compose -f ../../docker-compose.yml --profile dev up --build",
+    "docker:dev:telegram": "DOCKER_BUILDKIT=0 docker compose -f ../../docker-compose.yml --profile dev --profile telegram up --build",
+    "telegram:webhook": "npx tsx scripts/telegram-webhook.ts",
     "email:dev": "email dev --dir emails"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coomander",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,8 +30,11 @@
     "email:dev": "email dev --dir emails"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "3.0.84",
     "@anthropic-ai/sdk": "^0.80.0",
     "@coomander/core": "*",
+    "ai": "6.0.206",
+    "workers-ai-provider": "3.2.0",
     "agents": "0.14.5",
     "@radix-ui/react-alert-dialog": "1.1.15",
     "@radix-ui/react-dialog": "1.1.15",

--- a/apps/web/scripts/telegram-webhook.ts
+++ b/apps/web/scripts/telegram-webhook.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env npx tsx
+/**
+ * Register / inspect / clear the Telegram webhook for a Coomander bot (#215).
+ *
+ * Coomander's inbound is webhook-based (POST /api/coomander/webhook) and
+ * Telegram allows ONE webhook URL per bot. Prod's @coomander_bot already points
+ * at https://coomander.com/api/coomander/webhook, so LOCAL dev uses a SEPARATE
+ * dev bot (per developer) whose webhook points at that developer's Cloudflare
+ * Tunnel hostname. See README → "Local Telegram dev".
+ *
+ * Usage (from apps/web):
+ *   npm run telegram:webhook -- info        # getWebhookInfo (read-only, default)
+ *   npm run telegram:webhook -- set --yes   # setWebhook → $TELEGRAM_WEBHOOK_URL
+ *   npm run telegram:webhook -- delete      # deleteWebhook
+ *
+ * Reads from apps/web/.env.local:
+ *   MADDIE_TELEGRAM_BOT_TOKEN      the bot to operate on (your DEV bot in dev)
+ *   MADDIE_TELEGRAM_WEBHOOK_SECRET secret echoed in x-telegram-bot-api-secret-token
+ *   TELEGRAM_WEBHOOK_URL           full public URL, e.g.
+ *                                  https://dev-you.coomander.com/api/coomander/webhook
+ *
+ * Safety: `set` prints the resolved bot @username (getMe) and the target URL,
+ * then REQUIRES `--yes` — so you can't silently repoint the wrong bot (e.g.
+ * clobber prod's @coomander_bot if .env.local still holds the prod token).
+ */
+
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+const API = "https://api.telegram.org";
+
+type Cmd = "info" | "set" | "delete";
+
+interface TgResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+}
+
+async function tg<T>(token: string, method: string, body?: unknown): Promise<TgResponse<T>> {
+  const res = await fetch(`${API}/bot${token}/${method}`, {
+    method: body ? "POST" : "GET",
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return (await res.json().catch(() => ({ ok: false, description: `http ${res.status}` }))) as TgResponse<T>;
+}
+
+function fail(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const cmd = (args.find((a) => !a.startsWith("-")) ?? "info") as Cmd;
+  const yes = args.includes("--yes") || args.includes("-y");
+
+  if (!["info", "set", "delete"].includes(cmd)) {
+    fail(`unknown command "${cmd}". Use: info | set | delete`);
+  }
+
+  const token = process.env.MADDIE_TELEGRAM_BOT_TOKEN;
+  if (!token) fail("MADDIE_TELEGRAM_BOT_TOKEN not set in apps/web/.env.local");
+
+  // Always identify the target bot first — the guardrail against repointing the
+  // wrong bot (getMe is read-only).
+  const me = await tg<{ username?: string; id?: number }>(token, "getMe");
+  if (!me.ok) fail(`getMe failed: ${me.description ?? "unknown error"} (check MADDIE_TELEGRAM_BOT_TOKEN)`);
+  const botLabel = `@${me.result?.username ?? "?"} (id ${me.result?.id ?? "?"})`;
+  console.log(`Bot: ${botLabel}`);
+
+  if (cmd === "info") {
+    const info = await tg<Record<string, unknown>>(token, "getWebhookInfo");
+    if (!info.ok) fail(`getWebhookInfo failed: ${info.description}`);
+    const r = info.result ?? {};
+    console.log("Webhook info:");
+    console.log(`  url:                  ${r.url || "(none set)"}`);
+    console.log(`  pending_update_count: ${r.pending_update_count ?? 0}`);
+    console.log(`  has_custom_cert:      ${r.has_custom_certificate ?? false}`);
+    console.log(`  last_error_message:   ${r.last_error_message || "(none)"}`);
+    console.log(`  allowed_updates:      ${JSON.stringify(r.allowed_updates ?? "(default)")}`);
+    return;
+  }
+
+  if (cmd === "delete") {
+    const del = await tg(token, "deleteWebhook", { drop_pending_updates: true });
+    if (!del.ok) fail(`deleteWebhook failed: ${del.description}`);
+    console.log(`✓ Webhook deleted for ${botLabel}`);
+    return;
+  }
+
+  // cmd === "set"
+  const url = process.env.TELEGRAM_WEBHOOK_URL;
+  const secret = process.env.MADDIE_TELEGRAM_WEBHOOK_SECRET;
+  if (!url) fail("TELEGRAM_WEBHOOK_URL not set in apps/web/.env.local (e.g. https://dev-you.coomander.com/api/coomander/webhook)");
+  if (!secret) fail("MADDIE_TELEGRAM_WEBHOOK_SECRET not set in apps/web/.env.local");
+  if (!/^https:\/\//.test(url)) fail("TELEGRAM_WEBHOOK_URL must be https://");
+
+  console.log(`Will set webhook:\n  ${botLabel}\n  → ${url}`);
+  if (!yes) {
+    fail("refusing to set without confirmation. Re-run with --yes once you've verified the bot above is your DEV bot (not prod's @coomander_bot).");
+  }
+
+  const set = await tg(token, "setWebhook", {
+    url,
+    secret_token: secret,
+    allowed_updates: ["message"],
+    drop_pending_updates: true,
+  });
+  if (!set.ok) fail(`setWebhook failed: ${set.description}`);
+  console.log(`✓ Webhook set for ${botLabel} → ${url}`);
+}
+
+main().catch((e) => fail((e as Error).message));

--- a/apps/web/tests/coomander-inbound-model.test.ts
+++ b/apps/web/tests/coomander-inbound-model.test.ts
@@ -1,0 +1,334 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mocks for the collaborators resolveInboundModel calls. ---
+// We mock these so we can drive every branch of the resolution logic purely
+// from the spec, never touching the implementation under test.
+vi.mock("@/lib/active-model", () => ({
+  resolveActiveModelId: vi.fn(),
+}));
+vi.mock("@/lib/model-catalog", () => ({
+  getModel: vi.fn(),
+}));
+
+import {
+  resolveInboundModel,
+  ANTHROPIC_FALLBACK_ID,
+} from "@/lib/coomander/inbound-model";
+import { resolveActiveModelId } from "@/lib/active-model";
+import { getModel } from "@/lib/model-catalog";
+import { inboundTools } from "@/lib/coomander/inbound";
+
+const mockResolveActiveModelId = vi.mocked(resolveActiveModelId);
+const mockGetModel = vi.mocked(getModel);
+
+// Minimal catalog-entry shape factory. resolveInboundModel only ever inspects
+// id / provider / supportsTools, so that's all we populate. Cast through unknown
+// since the real ModelCatalogEntry has many more fields we don't care about.
+function entry(
+  partial: { id: string; provider: string; supportsTools: boolean },
+): ReturnType<typeof getModel> {
+  return partial as unknown as ReturnType<typeof getModel>;
+}
+
+describe("resolveInboundModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exports ANTHROPIC_FALLBACK_ID defaulting to claude-sonnet-4-6", () => {
+    expect(typeof ANTHROPIC_FALLBACK_ID).toBe("string");
+    expect(ANTHROPIC_FALLBACK_ID).toBe("claude-sonnet-4-6");
+  });
+
+  it("case 1: anthropic + tool-capable model resolves directly, no fallback", async () => {
+    mockResolveActiveModelId.mockResolvedValue("claude-opus-4-8");
+    mockGetModel.mockReturnValue(
+      entry({ id: "claude-opus-4-8", provider: "anthropic", supportsTools: true }),
+    );
+
+    const result = await resolveInboundModel("user-1");
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.resolvedId).toBe("claude-opus-4-8");
+    expect(result.fellBack).toBe(false);
+    expect(mockResolveActiveModelId).toHaveBeenCalledWith({ userId: "user-1" });
+  });
+
+  it("case 2: chosen model lacks tool support → falls back to Anthropic fallback", async () => {
+    mockResolveActiveModelId.mockResolvedValue(
+      "@cf/meta/llama-4-scout-17b-16e-instruct",
+    );
+    mockGetModel.mockReturnValue(
+      entry({
+        id: "@cf/meta/llama-4-scout-17b-16e-instruct",
+        provider: "cloudflare",
+        supportsTools: false,
+      }),
+    );
+
+    const result = await resolveInboundModel("user-1");
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.resolvedId).toBe(ANTHROPIC_FALLBACK_ID);
+    // Chosen id !== fallback id, so this counts as a fallback.
+    expect(result.fellBack).toBe(true);
+  });
+
+  it("case 3: unknown catalog id (getModel undefined) → falls back to Anthropic fallback", async () => {
+    mockResolveActiveModelId.mockResolvedValue("totally-made-up-model");
+    mockGetModel.mockReturnValue(undefined);
+
+    const result = await resolveInboundModel("user-1");
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.resolvedId).toBe(ANTHROPIC_FALLBACK_ID);
+    expect(result.fellBack).toBe(true);
+  });
+
+  it("case 4: resolveActiveModelId rejects → uses fallback id as chosen, not a fallback", async () => {
+    mockResolveActiveModelId.mockRejectedValue(new Error("db down"));
+    // The impl catches the rejection and uses ANTHROPIC_FALLBACK_ID as the
+    // chosen id, so getModel is asked for the fallback entry.
+    mockGetModel.mockImplementation((id: string) =>
+      id === ANTHROPIC_FALLBACK_ID
+        ? entry({
+            id: ANTHROPIC_FALLBACK_ID,
+            provider: "anthropic",
+            supportsTools: true,
+          })
+        : undefined,
+    );
+
+    const result = await resolveInboundModel("user-1");
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.resolvedId).toBe(ANTHROPIC_FALLBACK_ID);
+    // Chosen id === fallback id, so this is NOT counted as a fallback.
+    expect(result.fellBack).toBe(false);
+  });
+
+  // KNOWN LIMITATION: the impl reads the Workers AI binding via a CommonJS
+  // require("@opennextjs/cloudflare") that vi.mock cannot intercept. In the
+  // vitest (node) env, getCloudflareContext() throws and the binding resolves
+  // to null, so the cloudflare branch always falls back here. The "Workers AI
+  // binding PRESENT" success branch is therefore NOT unit-testable in this env
+  // (it is verified in prod instead). This case asserts the binding-ABSENT
+  // fallback path.
+  it("case 5: cloudflare + tool-capable but no env.AI binding → falls back to Anthropic fallback", async () => {
+    mockResolveActiveModelId.mockResolvedValue(
+      "@cf/meta/llama-4-scout-17b-16e-instruct",
+    );
+    mockGetModel.mockReturnValue(
+      entry({
+        id: "@cf/meta/llama-4-scout-17b-16e-instruct",
+        provider: "cloudflare",
+        supportsTools: true,
+      }),
+    );
+
+    const result = await resolveInboundModel("user-1");
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.resolvedId).toBe(ANTHROPIC_FALLBACK_ID);
+    expect(result.fellBack).toBe(true);
+  });
+
+  it("case 6: unwired provider (openai) → falls back to Anthropic fallback", async () => {
+    mockResolveActiveModelId.mockResolvedValue("x");
+    mockGetModel.mockReturnValue(
+      entry({ id: "x", provider: "openai", supportsTools: true }),
+    );
+
+    const result = await resolveInboundModel("user-1");
+
+    expect(result.provider).toBe("anthropic");
+    expect(result.resolvedId).toBe(ANTHROPIC_FALLBACK_ID);
+    expect(result.fellBack).toBe(true);
+  });
+});
+
+// --- Part B: inboundTools() zod input schemas. ---
+
+const TOOL_NAMES = [
+  "log_drop",
+  "advance_content_state",
+  "log_purchase",
+  "add_procurement_item",
+  "mark_blocker",
+  "adjust_beat",
+  "need_clarification",
+] as const;
+
+type ZodLike = { safeParse: (input: unknown) => { success: boolean } };
+
+// Locate the zod schema retained on a Vercel AI SDK tool object. In current
+// SDK versions it is `.inputSchema`, but guard against version drift by probing
+// known alternates (`.parameters`) before failing loudly.
+function schemaFor(name: (typeof TOOL_NAMES)[number]): ZodLike {
+  const tool = inboundTools()[name] as Record<string, unknown>;
+  const candidate =
+    (tool.inputSchema as unknown) ??
+    (tool.parameters as unknown) ??
+    undefined;
+  if (candidate && typeof (candidate as ZodLike).safeParse === "function") {
+    return candidate as ZodLike;
+  }
+  throw new Error(
+    `Could not locate zod schema for tool "${name}". Tool object keys: ${Object.keys(
+      tool,
+    ).join(", ")}`,
+  );
+}
+
+function parses(name: (typeof TOOL_NAMES)[number], input: unknown): boolean {
+  return schemaFor(name).safeParse(input).success;
+}
+
+describe("inboundTools()", () => {
+  it("exposes exactly the 7 expected tool names", () => {
+    expect(Object.keys(inboundTools()).sort()).toEqual([...TOOL_NAMES].sort());
+  });
+
+  describe("log_drop schema", () => {
+    it("parses with required beat_id + valid kind", () => {
+      expect(parses("log_drop", { beat_id: "b", kind: "shipped" })).toBe(true);
+    });
+    it("fails when beat_id is missing", () => {
+      expect(parses("log_drop", { kind: "shipped" })).toBe(false);
+    });
+    it("accepts the other valid kinds", () => {
+      expect(parses("log_drop", { beat_id: "b", kind: "captured" })).toBe(true);
+      expect(parses("log_drop", { beat_id: "b", kind: "completed" })).toBe(true);
+    });
+    it("fails on an invalid kind", () => {
+      expect(parses("log_drop", { beat_id: "b", kind: "bogus" })).toBe(false);
+    });
+    it("accepts optional count/platform/notes", () => {
+      // platform is an enum (ig/tiktok/fb/snap/of) — use a valid member so this
+      // verifies optionality, not the enum constraint.
+      expect(
+        parses("log_drop", {
+          beat_id: "b",
+          kind: "shipped",
+          count: 2,
+          platform: "tiktok",
+          notes: "n",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("advance_content_state schema", () => {
+    it("parses with content_id + new_state", () => {
+      expect(
+        parses("advance_content_state", { content_id: "c", new_state: "shot" }),
+      ).toBe(true);
+    });
+    it("fails without content_id", () => {
+      expect(parses("advance_content_state", { new_state: "shot" })).toBe(false);
+    });
+    it("fails without new_state", () => {
+      expect(parses("advance_content_state", { content_id: "c" })).toBe(false);
+    });
+    it("accepts optional notes", () => {
+      expect(
+        parses("advance_content_state", {
+          content_id: "c",
+          new_state: "shot",
+          notes: "n",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("log_purchase schema", () => {
+    it("parses with procurement_item_id", () => {
+      expect(parses("log_purchase", { procurement_item_id: "p" })).toBe(true);
+    });
+    it("fails without procurement_item_id", () => {
+      expect(parses("log_purchase", {})).toBe(false);
+    });
+    it("accepts optional actual_cost/notes", () => {
+      expect(
+        parses("log_purchase", {
+          procurement_item_id: "p",
+          actual_cost: 12.5,
+          notes: "n",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("add_procurement_item schema", () => {
+    it("parses with valid category + label", () => {
+      expect(
+        parses("add_procurement_item", {
+          category: "shoot_prep",
+          label: "ring light",
+        }),
+      ).toBe(true);
+      expect(
+        parses("add_procurement_item", {
+          category: "business_admin",
+          label: "filing",
+        }),
+      ).toBe(true);
+    });
+    it("fails without category", () => {
+      expect(parses("add_procurement_item", { label: "ring light" })).toBe(false);
+    });
+    it("fails without label", () => {
+      expect(parses("add_procurement_item", { category: "shoot_prep" })).toBe(
+        false,
+      );
+    });
+    it("fails on an invalid category", () => {
+      expect(
+        parses("add_procurement_item", { category: "misc", label: "x" }),
+      ).toBe(false);
+    });
+    it("accepts optional needed_by/notes", () => {
+      expect(
+        parses("add_procurement_item", {
+          category: "shoot_prep",
+          label: "ring light",
+          needed_by: "2026-06-25",
+          notes: "n",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("mark_blocker schema", () => {
+    it("parses with reason only", () => {
+      expect(parses("mark_blocker", { reason: "sick" })).toBe(true);
+    });
+    it("fails without reason", () => {
+      expect(parses("mark_blocker", {})).toBe(false);
+    });
+    it("accepts optional beat_id", () => {
+      expect(parses("mark_blocker", { reason: "sick", beat_id: "b" })).toBe(true);
+    });
+  });
+
+  describe("adjust_beat schema", () => {
+    it("parses with beat_id only", () => {
+      expect(parses("adjust_beat", { beat_id: "b" })).toBe(true);
+    });
+    it("fails without beat_id", () => {
+      expect(parses("adjust_beat", {})).toBe(false);
+    });
+    it("accepts optional target_count", () => {
+      expect(parses("adjust_beat", { beat_id: "b", target_count: 5 })).toBe(true);
+    });
+  });
+
+  describe("need_clarification schema", () => {
+    it("parses with reply", () => {
+      expect(parses("need_clarification", { reply: "huh?" })).toBe(true);
+    });
+    it("fails without reply", () => {
+      expect(parses("need_clarification", {})).toBe(false);
+    });
+  });
+});

--- a/apps/web/tests/coomander-inbound-today.test.ts
+++ b/apps/web/tests/coomander-inbound-today.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { isTodayPlanQuestion, todayPlanReply } from "@/lib/coomander/inbound";
+import type { TodayModel } from "@/lib/coomander/todayModel";
+import type { CadenceBeat, ProcurementItem } from "@/lib/schema";
+
+function beat(name: string, subtype: string | null = null): CadenceBeat {
+  return {
+    id: name.toLowerCase().replaceAll(" ", "-"),
+    name,
+    cadence_kind: "daily",
+    target_count: 3,
+    subtype,
+  } as CadenceBeat;
+}
+
+function model(): TodayModel {
+  return {
+    date: "2026-06-24",
+    pillars: [
+      {
+        pillar: { id: "content", name: "Content" } as never,
+        beats: [
+          {
+            beat: beat("Normal reel", "normal_reel"),
+            expected_today: 3,
+            actual_today: 1,
+            status: "behind",
+          },
+          {
+            beat: {
+              ...beat("Daily-vlog wall capture"),
+              cadence_kind: "daily_vlog_buffer",
+            },
+            expected_today: 0,
+            actual_today: 0,
+            buffer_status: { current_days: 0, goal_days: 3, healthy: false },
+            status: "buffer_low",
+          },
+        ],
+      },
+    ],
+    content_pipeline: {
+      drafted: 0,
+      shot: 0,
+      approved: 0,
+      uploaded_to_edit: 0,
+      edited: 0,
+      scheduled: 0,
+      shipped: 0,
+      shipped_today: 0,
+    },
+    content_cushion_days: 1,
+    procurement_urgent: {
+      shoot_prep: [
+        {
+          label: "ring light",
+          needed_by: "2026-06-25",
+        } as ProcurementItem,
+      ],
+      business_admin: [],
+    },
+    day_quality: null,
+    overall_state: "red",
+  };
+}
+
+describe("Telegram today-plan questions", () => {
+  it.each([
+    "What do I need to get done today?",
+    "What should I focus on today?",
+    "What's on my plate today?",
+    "What is the plan for today?",
+  ])("recognizes %s", (text) => {
+    expect(isTodayPlanQuestion(text)).toBe(true);
+  });
+
+  it("does not intercept execution updates", () => {
+    expect(isTodayPlanQuestion("Posted the gym reel")).toBe(false);
+    expect(isTodayPlanQuestion("I need a ring light")).toBe(false);
+  });
+
+  it("answers from ramp-aware cadence, buffers, and urgent procurement", () => {
+    expect(todayPlanReply(model(), 2)).toBe(
+      "Today: Normal reel: 2 remaining; Daily-vlog wall capture: build the buffer (0/3 days); Get ring light by 2026-06-25. Content cushion: 1 day.",
+    );
+  });
+});

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -67,11 +67,16 @@ FLAG_COOMANDER_AGENTS_CHAT = "true"
 # (also needs the CF_ANALYTICS_API_TOKEN secret + the CLOUDFLARE_ACCOUNT_ID
 # above, with the "Account Analytics: Read" grant).
 AI_GATEWAY_ID = "coomander-gateway"
-#
-# NOTE: the web worker intentionally has NO [ai] binding. Workers AI (if added
-# later) runs on the AGENTS worker (apps/agents), which would declare its own
-# [ai] binding there. Don't re-add one here unless web code actually calls
-# Workers AI directly.
+
+# ── Workers AI binding (#218) ──────────────────────────────────────────
+# The web worker NOW calls Workers AI directly: the Telegram inbound classifier
+# (lib/coomander/inbound.ts → inbound-model.ts) dispatches the admin/user-chosen
+# model through the multi-provider engine, running open `@cf/...` models via
+# createWorkersAI({ binding: env.AI }). Named envs don't inherit bindings, so
+# this is redeclared under [env.production.ai] below. In `next dev` there is no
+# binding, so Workers-AI choices fall back to Anthropic (handled in inbound-model).
+[ai]
+binding = "AI"
 
 
 # ── D1 (Cloudflare's serverless SQLite) ────────────────────────────────
@@ -135,3 +140,8 @@ deleted_classes = ["AppAgent"]
 # created.
 [env.production]
 name = "coomander"
+
+# Workers AI binding (#218) — NOT inherited from the top-level env, so redeclare
+# it for production. Powers the Telegram inbound classifier's Workers-AI path.
+[env.production.ai]
+binding = "AI"

--- a/changelogs/2026-06-23-dev-telegram-tunnel.md
+++ b/changelogs/2026-06-23-dev-telegram-tunnel.md
@@ -1,0 +1,44 @@
+---
+date: 2026-06-23
+scope: [node]
+category: feature
+files_changed:
+  - docker-compose.yml
+  - apps/web/scripts/telegram-webhook.ts
+  - apps/web/package.json
+  - .env.example
+  - apps/web/.env.example
+  - README.md
+requires_migration: false
+requires_env_vars: [CLOUDFLARE_TUNNEL_TOKEN, TELEGRAM_WEBHOOK_URL, COOMANDER_BOT_USERNAME]
+breaking: false
+---
+
+## Local Telegram dev: per-developer dev bot + Cloudflare Tunnel
+
+Lets any contributor run the dev server and use Telegram locally — the bot
+replying and the **Connect Telegram** link flow — against their own machine.
+
+Telegram allows **one webhook URL per bot**, and prod's `@coomander_bot` owns it,
+so each developer runs **their own dev bot** (BotFather) plus a **persistent
+Cloudflare named tunnel** that publishes a stable public hostname
+(`dev-<you>.coomander.com`) scoped to just the `/api/coomander/webhook` path.
+Everything is env-driven — **no app code changes**.
+
+- **`cloudflared` sidecar** in `docker-compose.yml`, opt-in via
+  `--profile telegram` (plain `docker compose up` is unaffected). Shares
+  `caddy-dev`'s netns so the tunnel reaches next dev at `localhost:3000`. Reads
+  `CLOUDFLARE_TUNNEL_TOKEN` (repo-root `.env`).
+- **`npm run telegram:webhook -- set|info|delete`**
+  (`apps/web/scripts/telegram-webhook.ts`) registers/inspects/clears the webhook
+  from `MADDIE_TELEGRAM_BOT_TOKEN` + `MADDIE_TELEGRAM_WEBHOOK_SECRET` +
+  `TELEGRAM_WEBHOOK_URL`. Prints the resolved bot `@username` (getMe) and
+  requires `--yes` to `set` — a guard against repointing prod's bot.
+- **`COOMANDER_BOT_USERNAME`** already drives the Connect deep link; set it to
+  your dev bot's username so the flow points at the dev bot in dev.
+- New convenience script `npm run docker:dev:telegram`; new env vars documented
+  in both `.env.example` files; README gains a "Local Telegram dev" section.
+
+Downstream projects with their own Telegram bot follow the same pattern: a dev
+bot + a named tunnel, with `COOMANDER_BOT_USERNAME`/`TELEGRAM_WEBHOOK_URL` per
+developer. Nothing here touches production.

--- a/changelogs/2026-06-24-inbound-multiprovider.md
+++ b/changelogs/2026-06-24-inbound-multiprovider.md
@@ -1,0 +1,46 @@
+---
+date: 2026-06-24
+scope: [node]
+category: fix
+files_changed:
+  - apps/web/lib/coomander/inbound.ts
+  - apps/web/lib/coomander/inbound-model.ts
+  - apps/web/lib/coomander/coomanderChat.ts
+  - apps/web/wrangler.toml
+  - apps/web/package.json
+requires_migration: false
+requires_env_vars: []
+breaking: false
+---
+
+## Telegram inbound classifier routes through the multi-provider engine
+
+The Telegram inbound classifier (`lib/coomander/inbound.ts`) hardcoded the model
+(`new Anthropic()` + a `MODEL` env const) and bypassed the multi-provider engine,
+so the admin/per-user model switcher did nothing for Telegram and the inbound
+path could never run credit-free on Workers AI. Now it resolves the chosen model
+via `resolveActiveModel`/`resolveActiveModelId` and dispatches Anthropic + Workers
+AI through the Vercel AI SDK — mirroring the agents-worker chat path
+(`apps/agents/src/chat-model.ts`). (Port of geology #282/#288.)
+
+- **New `lib/coomander/inbound-model.ts`** — `resolveInboundModel(userId)` maps the
+  chosen catalog entry to an AI SDK `LanguageModel`: `anthropic` → `createAnthropic`,
+  `cloudflare` → `createWorkersAI({ binding: env.AI })`. Forced tool-calling means
+  any model without tool support (or unknown id / missing `env.AI` binding / unwired
+  provider) falls back to the Anthropic default, logged; classification never breaks.
+- **`classifyMessage` → `generateText`** with `toolChoice: "required"`; tool defs
+  converted to AI SDK `tool()` + zod (`inboundTools()`), keeping every tool/property
+  name identical so `resolveToolUse`/`executeAction`/the webhook are untouched.
+  Usage now logs the actually-resolved model id (AI-SDK `inputTokens`/`outputTokens`).
+- **`[ai]` binding** added to `apps/web/wrangler.toml` (top-level + `[env.production]`)
+  so the web worker can run Workers AI directly. In `next dev` there is no binding,
+  so Workers-AI choices fall back to Anthropic (real WAI runs only in the deployed
+  worker).
+- **deps** (match `apps/agents`): `ai@6.0.206`, `@ai-sdk/anthropic@3.0.84`,
+  `workers-ai-provider@3.2.0`. Lockfile regenerated without dropping Linux platform binaries.
+
+The Anthropic-format tool schemas the agents-worker chat path consumes
+(`coomanderChat.chatTools()`) were relocated there verbatim (no agent-path change);
+they must stay in sync with `inboundTools()`. Note: coomander's `usage.ts` records
+only raw token counts (no cost-rate table), so there is no Workers-AI cost
+mispricing to fix here (unlike geology #287).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,40 @@ services:
       NODE_ENV: development
     restart: unless-stopped
 
+  # ── Cloudflare Tunnel (opt-in: Telegram webhook in dev, #215) ────────────
+  # Telegram inbound is webhook-based and Telegram allows ONE webhook per bot,
+  # so each developer runs their OWN dev bot + their OWN named tunnel (prod's
+  # @coomander_bot owns the coomander.com webhook). This sidecar connects a
+  # Cloudflare *named* tunnel that publishes a stable public hostname
+  # (e.g. https://dev-<you>.coomander.com) so Telegram's servers can reach this
+  # machine's /api/coomander/webhook. Scope the tunnel's ingress to ONLY that
+  # path in the Cloudflare Zero Trust dashboard so the rest of the dev app stays
+  # private. See README → "Local Telegram dev".
+  #
+  # Opt-in: `docker compose --profile telegram up`. Plain `docker compose up`
+  # does NOT start it (no token needed for normal dev). Shares caddy-dev's netns
+  # so the tunnel's service target `http://localhost:3000` reaches next dev.
+  # cloudflared reads the token from TUNNEL_TOKEN natively; set
+  # CLOUDFLARE_TUNNEL_TOKEN in the repo-root .env (compose interpolation source).
+  cloudflared:
+    profiles: ["telegram"]
+    image: cloudflare/cloudflared:2026.6.1
+    container_name: coomander-cloudflared
+    network_mode: service:caddy-dev
+    depends_on:
+      - caddy-dev
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN:-}
+      # Bypass OrbStack's HTTP proxy for tunnel egress (mirrors caddy-dev).
+      HTTP_PROXY: ""
+      HTTPS_PROXY: ""
+      NO_PROXY: "*"
+      http_proxy: ""
+      https_proxy: ""
+      no_proxy: "*"
+    command: tunnel --no-autoupdate run
+    restart: unless-stopped
+
 volumes:
   root_node_modules:
   web_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,9 @@ services:
       - agents_local_node_modules:/app/apps/agents/node_modules
     environment:
       NODE_ENV: development
+      # Keep Docker chat available with only ANTHROPIC_API_KEY configured.
+      # Set false when intentionally testing the remote Workers AI binding.
+      COOMANDER_AGENTS_LOCAL_ONLY: ${COOMANDER_AGENTS_LOCAL_ONLY:-true}
     restart: unless-stopped
 
   # ── Cloudflare Tunnel (opt-in: Telegram webhook in dev, #215) ────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -998,6 +998,7 @@
       "version": "0.2.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@ai-sdk/anthropic": "3.0.84",
         "@anthropic-ai/sdk": "^0.80.0",
         "@coomander/core": "*",
         "@radix-ui/react-alert-dialog": "1.1.15",
@@ -1014,6 +1015,7 @@
         "@sentry/nextjs": "^10.46.0",
         "@types/qrcode": "^1.5.6",
         "agents": "0.14.5",
+        "ai": "6.0.206",
         "ajv": "^8.18.0",
         "better-auth": "1.4.18",
         "better-sqlite3": "^12.6.2",
@@ -1046,6 +1048,7 @@
         "stripe": "^17.0.0",
         "tailwind-merge": "3.5.0",
         "tw-animate-css": "1.4.0",
+        "workers-ai-provider": "3.2.0",
         "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
@@ -1067,6 +1070,52 @@
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.0.18"
+      }
+    },
+    "apps/web/node_modules/@ai-sdk/gateway": {
+      "version": "3.0.132",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.132.tgz",
+      "integrity": "sha512-sFZFGk6aVSNKmgDrb14efaAbvM71AB3UUvaTsU+bvhWP9jrkRrwix/jFX8IoOAJk0/X7Xf7p3m0J2O2G6ljZbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.29",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "apps/web/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/web/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.29.tgz",
+      "integrity": "sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "apps/web/node_modules/@esbuild/aix-ppc64": {
@@ -1485,6 +1534,15 @@
         "node": ">=18"
       }
     },
+    "apps/web/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "apps/web/node_modules/agents": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/agents/-/agents-0.14.5.tgz",
@@ -1569,6 +1627,24 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "apps/web/node_modules/ai": {
+      "version": "6.0.206",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.206.tgz",
+      "integrity": "sha512-hVdB5PozMMxmkPBfbCxkFOn0eVeCMi/imkfPvk65cxL4O8oIrvjUxDUX8dGkdkWG1No+R7e7D9ti2DHO61Z4YQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.132",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.29",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "apps/web/node_modules/fumadocs-mdx": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coomander-monorepo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coomander-monorepo",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -14,7 +14,7 @@
     },
     "apps/agents": {
       "name": "@coomander/agents",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.84",
         "@coomander/core": "*",
@@ -995,7 +995,7 @@
     },
     "apps/web": {
       "name": "coomander",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.84",
@@ -37616,7 +37616,7 @@
     },
     "packages/core": {
       "name": "@coomander/core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "better-auth": "1.4.18",
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coomander-monorepo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coomander/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Platform-agnostic core: Zod schemas, shared types, and a typed API client. No next/*, drizzle, better-sqlite3, react-dom, Node built-ins, or DOM globals (must run in React Native).",


### PR DESCRIPTION
## Release v0.3.0 → production

Promotes `develop` to `main` (prod deploys from `main` via Workers Builds).

### Included
- **#218 / #219** — Telegram inbound classifier routes through the multi-provider engine (Anthropic + Workers AI), honoring the admin/per-user model switcher; adds the `[ai]` binding to the web worker. **Prod-only effect:** Workers-AI inbound runs credit-free; dev falls back to Anthropic (no `[ai]` binding).
- **#215 / #216** — Local Telegram dev plumbing (per-developer dev bot + Cloudflare Tunnel sidecar). Dev-infra only; no prod runtime impact.
- Dev chat / Telegram-planning stabilization (5111c6f).
- Version bump `0.2.0 → 0.3.0`.

### Verification (on develop)
- Full suite **644 pass**; `tsc --noEmit` clean; `next build` succeeds; lockfile regenerated without dropping Linux platform binaries.

### Post-deploy QA
- #220 — inbound multi-provider (needs prod for the Workers-AI path).

No migrations.